### PR TITLE
Issue/1283 - Solve bugs related to Display Unit select in TimePicker GUI

### DIFF
--- a/src/components/BottomBar/SimulationIncrement.jsx
+++ b/src/components/BottomBar/SimulationIncrement.jsx
@@ -190,7 +190,6 @@ class SimulationIncrement extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    time: state.time.time,
     deltaTime: state.time.deltaTime,
     targetDeltaTime: state.time.targetDeltaTime,
     isPaused: state.time.isPaused,

--- a/src/components/common/Input/Select/Select.jsx
+++ b/src/components/common/Input/Select/Select.jsx
@@ -58,6 +58,7 @@ const Select = (props) => {
         placeholder={label}
         styles={selectStyles}
         value={inheritedProps.options.filter(opt => opt.value == value)}
+        blurInputOnSelect
       />
       { props.value !== undefined && <label htmlFor={id} className={styles.selectlabel}>{ label }</label> }
     </div>


### PR DESCRIPTION
Solve the visual bugs described in issue OpenSpace/OpenSpace#1283. 

The change in the Select component applied to all these components, so that they don't keep hijacking keyboard input after an option is selected. We should probably discuss during the next Monday meeting whether this is the expected behavior for all possible drop down selection list, or if the `blurInputOnSelect` should be added to individual Selects instead. 