### PR TITLE
Update webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,7 +57,9 @@ module.exports = {
             options: {
               sourceMap: true,
               importLoaders: 2,
-              modules: true
+              modules: {
+                localIdentName: "[path][name]__[local]--[hash:base64:7]",
+              }
             },
           }, {
             loader: 'sass-loader',


### PR DESCRIPTION
During development there is no need for pure hash classnames. Change to traceable names for ease of development