### PR TITLE
Numeric slider updates

### DIFF
--- a/src/components/Sidebar/Properties/BoolProperty.jsx
+++ b/src/components/Sidebar/Properties/BoolProperty.jsx
@@ -3,6 +3,7 @@ import Checkbox from '../../common/Input/Checkbox/Checkbox';
 import { connectProperty } from './connectProperty';
 import InfoBox from '../../common/InfoBox/InfoBox';
 import { copyTextToClipboard } from '../../../utils/helpers';
+import styles from './Property.scss';
 
 class BoolProperty extends Component {
   constructor(props) {
@@ -44,13 +45,15 @@ class BoolProperty extends Component {
     const showText = !this.props.checkBoxOnly;
 
     return (
-      <Checkbox
-        wide={!this.props.checkBoxOnly}
-        checked={value}
-        label={showText ? (<span>{description.Name} {this.descriptionPopup}</span>) : null}
-        setChecked={this.onChange}
-        disabled={this.disabled}
-      />
+      <div className={`${this.disabled ? styles.disabled : ''}`}>
+        <Checkbox
+          wide={!this.props.checkBoxOnly}
+          checked={value}
+          label={showText ? (<span>{description.Name} {this.descriptionPopup}</span>) : null}
+          setChecked={this.onChange}
+          disabled={this.disabled}
+        />
+      </div>
     );
   }
 }

--- a/src/components/Sidebar/Properties/ListProperty.jsx
+++ b/src/components/Sidebar/Properties/ListProperty.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Input from '../../common/Input/Input/Input';
 import InfoBox from '../../common/InfoBox/InfoBox';
 import { copyTextToClipboard } from '../../../utils/helpers';
+import styles from './Property.scss';
 
 class ListProperty extends Component {
   constructor(props) {
@@ -43,13 +44,15 @@ class ListProperty extends Component {
       { description.Name } { this.descriptionPopup }
     </span>);
     return (
-      <Input
-        value={value.join(',')}
-        label={label}
-        placeholder={description.Name}
-        onEnter={this.onChange}
-        disabled={this.disabled}
-      />
+      <div className={`${this.disabled ? styles.disabled : ''}`}>
+        <Input
+          value={value.join(',')}
+          label={label}
+          placeholder={description.Name}
+          onEnter={this.onChange}
+          disabled={this.disabled}
+        />
+      </div>
     );
   }
 }

--- a/src/components/Sidebar/Properties/MatrixProperty.jsx
+++ b/src/components/Sidebar/Properties/MatrixProperty.jsx
@@ -34,10 +34,6 @@ class MatrixProperty extends Component {
     return this.props.description.MetaData.isReadOnly;
   }
 
-  get logarithmicView() {
-    return this.props.description.MetaData.ViewOptions.Logarithmic;
-  }
-
   onChange(index) {
     return (newValue) => {
       const stateValue = this.props.value;
@@ -48,7 +44,7 @@ class MatrixProperty extends Component {
 
   render() {
     const { description, value } = this.props;
-    const { SteppingValue, MaximumValue, MinimumValue } = description.AdditionalData;
+    const { SteppingValue, MaximumValue, MinimumValue, Exponent } = description.AdditionalData;
     const firstLabel = (
       <span onClick={this.copyUri}>
         { description.Name } { this.descriptionPopup }
@@ -78,12 +74,12 @@ class MatrixProperty extends Component {
                 label={comp.index === 0 ? firstLabel : ' '}
                 placeholder={`value ${comp.index}`}
                 onValueChanged={this.onChange(comp.index)}
+                exponent={Exponent}
                 step={SteppingValue[comp.index] || 0.01}
                 max={MaximumValue[comp.index] || 100}
                 min={MinimumValue[comp.index] || -100}
                 disabled={this.disabled}
                 noTooltip
-                logarithmicScale={this.logarithmicView}
               />
             ))}
           </Row>

--- a/src/components/Sidebar/Properties/MatrixProperty.jsx
+++ b/src/components/Sidebar/Properties/MatrixProperty.jsx
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import NumericInput from '../../common/Input/NumericInput/NumericInput';
 import Row from '../../common/Row/Row';
 import InfoBox from '../../common/InfoBox/InfoBox';
-import styles from './Property.scss';
 import { connectProperty } from './connectProperty';
 import { copyTextToClipboard } from '../../../utils/helpers';
+import styles from './Property.scss';
 
 class MatrixProperty extends Component {
   constructor(props) {
@@ -63,7 +63,7 @@ class MatrixProperty extends Component {
 
     // eslint-disable react/no-array-index-key
     return (
-      <div className={styles.matrixProperty}>
+      <div className={`${styles.matrixProperty} ${this.disabled ? styles.disabled : ''}`}>>
         { groups.map((group, index) => (
           <Row key={`row-${index}`}>
             { group.map(comp => (

--- a/src/components/Sidebar/Properties/NumericProperty.jsx
+++ b/src/components/Sidebar/Properties/NumericProperty.jsx
@@ -3,6 +3,7 @@ import NumericInput from '../../common/Input/NumericInput/NumericInput';
 import InfoBox from '../../common/InfoBox/InfoBox';
 import { connectProperty } from './connectProperty';
 import { copyTextToClipboard } from '../../../utils/helpers';
+import styles from './Property.scss';
 
 class NumericProperty extends Component {
   constructor(props) {
@@ -47,17 +48,19 @@ class NumericProperty extends Component {
     const { description, value } = this.props;
     const { SteppingValue, MaximumValue, MinimumValue, Exponent } = description.AdditionalData;
     return (
-      <NumericInput
-        value={value}
-        label={(<span onClick={this.copyUri}>{description.Name} {this.descriptionPopup}</span>)}
-        placeholder={description.Name}
-        onValueChanged={this.onChange}
-        step={SteppingValue}
-        exponent={Exponent}
-        max={MaximumValue}
-        min={MinimumValue}
-        disabled={this.disabled}
-      />
+      <div className={`${this.disabled ? styles.disabled : ''}`}>
+        <NumericInput
+          value={value}
+          label={(<span onClick={this.copyUri}>{description.Name} {this.descriptionPopup}</span>)}
+          placeholder={description.Name}
+          onValueChanged={this.onChange}
+          step={SteppingValue}
+          exponent={Exponent}
+          max={MaximumValue}
+          min={MinimumValue}
+          disabled={this.disabled}
+        />
+      </div>
     );
   }
 }

--- a/src/components/Sidebar/Properties/NumericProperty.jsx
+++ b/src/components/Sidebar/Properties/NumericProperty.jsx
@@ -28,10 +28,6 @@ class NumericProperty extends Component {
     return this.props.description.MetaData.isReadOnly;
   }
 
-  get logarithmicView() {
-    return this.props.description.MetaData.ViewOptions.Logarithmic;
-  }
-
   onChange(newValue) {
     this.props.dispatcher.set(newValue);
   }
@@ -49,7 +45,7 @@ class NumericProperty extends Component {
 
   render() {
     const { description, value } = this.props;
-    const { SteppingValue, MaximumValue, MinimumValue } = description.AdditionalData;
+    const { SteppingValue, MaximumValue, MinimumValue, Exponent } = description.AdditionalData;
     return (
       <NumericInput
         value={value}
@@ -57,10 +53,10 @@ class NumericProperty extends Component {
         placeholder={description.Name}
         onValueChanged={this.onChange}
         step={SteppingValue}
+        exponent={Exponent}
         max={MaximumValue}
         min={MinimumValue}
         disabled={this.disabled}
-        logarithmicScale={this.logarithmicView}
       />
     );
   }

--- a/src/components/Sidebar/Properties/OptionProperty.jsx
+++ b/src/components/Sidebar/Properties/OptionProperty.jsx
@@ -3,6 +3,7 @@ import Select from '../../common/Input/Select/Select';
 import InfoBox from '../../common/InfoBox/InfoBox';
 import { connectProperty } from './connectProperty';
 import { copyTextToClipboard } from '../../../utils/helpers';
+import styles from './Property.scss';
 
 class OptionProperty extends Component {
   constructor(props) {
@@ -50,14 +51,17 @@ class OptionProperty extends Component {
         value: ('' + Object.keys(option)[0]),
         isSelected: ('' + Object.keys(option)[0]) === ('' + value)
       }));
+      
     return (
-      <Select
-        label={label}
-        options={options}
-        onChange={this.onChange}
-        disabled={this.disabled}
-        value={value}
-      />
+      <div className={`${this.disabled ? styles.disabled : ''}`}>
+        <Select
+          label={label}
+          options={options}
+          onChange={this.onChange}
+          disabled={this.disabled}
+          value={value}
+        />
+      </div>
     );
   }
 }

--- a/src/components/Sidebar/Properties/Property.scss
+++ b/src/components/Sidebar/Properties/Property.scss
@@ -16,3 +16,8 @@
     height: 100%;
   }
 }
+
+.disabled {
+  pointer-events: none;
+  color: darken($text-color-focus, 30%) !important;
+}

--- a/src/components/Sidebar/Properties/SelectionProperty.jsx
+++ b/src/components/Sidebar/Properties/SelectionProperty.jsx
@@ -107,6 +107,7 @@ class SelectionProperty extends Component {
         expanded={this.state.expanded}
         setExpanded={this.setExpanded}
       >
+        {/* @TODO (emmbr, 2021-05-27): this property type cannot be disabled */}
         {/* <div className={`${this.disabled ? styles.disabled : ''}`}> */}
           { (options.length > 10) && helperButtons }
           {

--- a/src/components/Sidebar/Properties/SelectionProperty.jsx
+++ b/src/components/Sidebar/Properties/SelectionProperty.jsx
@@ -5,6 +5,7 @@ import { copyTextToClipboard } from '../../../utils/helpers';
 import ToggleContent from '../../common/ToggleContent/ToggleContent';
 import Checkbox from '../../common/Input/Checkbox/Checkbox';
 import Button from '../../common/Input/Button/Button';
+import styles from './Property.scss';
 
 class SelectionProperty extends Component {
   constructor(props) {
@@ -98,26 +99,28 @@ class SelectionProperty extends Component {
       </span>
     )
 
+      console.log(this.disabled);
+
     return (
       <ToggleContent
         title={label}
         expanded={this.state.expanded}
         setExpanded={this.setExpanded}
       >
-        {
-          (options.length > 10) && helperButtons
-        }
-        {
-          options.map(opt => 
-            <Checkbox
-              key={opt}
-              label={opt}
-              checked={this.isSelected(opt)}
-              setChecked={(checked) => { this.onCheckboxChange(checked, opt); }}
-              disabled={this.disabled}
-            />
-          )
-        }
+        {/* <div className={`${this.disabled ? styles.disabled : ''}`}> */}
+          { (options.length > 10) && helperButtons }
+          {
+            options.map(opt => 
+              <Checkbox
+                key={opt}
+                label={opt}
+                checked={this.isSelected(opt)}
+                setChecked={(checked) => { this.onCheckboxChange(checked, opt); }}
+                disabled={this.disabled}
+              />
+            )
+          }
+        {/* </div> */}
       </ToggleContent>
     );
   }

--- a/src/components/Sidebar/Properties/StringProperty.jsx
+++ b/src/components/Sidebar/Properties/StringProperty.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Input from '../../common/Input/Input/Input';
 import InfoBox from '../../common/InfoBox/InfoBox';
 import { copyTextToClipboard } from '../../../utils/helpers';
+import styles from './Property.scss';
 
 class StringProperty extends Component {
   constructor(props) {
@@ -43,13 +44,15 @@ class StringProperty extends Component {
       { description.Name } { this.descriptionPopup }
     </span>);
     return (
-      <Input
-        value={value}
-        label={label}
-        placeholder={description.Name}
-        onEnter={this.onChange}
-        disabled={this.disabled}
-      />
+      <div className={`${this.disabled ? styles.disabled : ''}`}>
+        <Input
+          value={value}
+          label={label}
+          placeholder={description.Name}
+          onEnter={this.onChange}
+          disabled={this.disabled}
+        />
+      </div>
     );
   }
 }

--- a/src/components/Sidebar/Properties/VectorProperty.jsx
+++ b/src/components/Sidebar/Properties/VectorProperty.jsx
@@ -36,10 +36,6 @@ class VectorProperty extends Component {
     return this.props.description.MetaData.isReadOnly;
   }
 
-  get logarithmicView() {
-    return this.props.description.MetaData.ViewOptions.Logarithmic;
-  }
-
   get isColor() {
     if(this.props.value.length < 3 || this.props.value.length > 4) {
       return false;
@@ -87,7 +83,7 @@ class VectorProperty extends Component {
 
   render() {
     const { description } = this.props;
-    const { SteppingValue, MaximumValue, MinimumValue } = description.AdditionalData;
+    const { SteppingValue, MaximumValue, MinimumValue, Exponent } = description.AdditionalData;
     const firstLabel = (<span onClick={this.copyUri}>
       { description.Name } { this.descriptionPopup }
     </span>);
@@ -106,10 +102,10 @@ class VectorProperty extends Component {
             placeholder={`value ${index}`}
             onValueChanged={this.onChange(index)}
             step={SteppingValue[index]}
+            exponent={Exponent}
             max={MaximumValue[index]}
             min={MinimumValue[index]}
             disabled={this.disabled}
-            logarithmicScale={this.logarithmicView}
           />
         ))}
         { this.isColor && (

--- a/src/components/Sidebar/Properties/VectorProperty.jsx
+++ b/src/components/Sidebar/Properties/VectorProperty.jsx
@@ -3,9 +3,9 @@ import NumericInput from '../../common/Input/NumericInput/NumericInput';
 import MinMaxRangeInput from '../../common/Input/MinMaxRangeInput/MinMaxRangeInput';
 import Row from '../../common/Row/Row';
 import InfoBox from '../../common/InfoBox/InfoBox';
-import styles from './Property.scss';
 import { copyTextToClipboard } from '../../../utils/helpers';
 import ColorPickerPopup from '../../common/ColorPicker/ColorPickerPopup';
+import styles from './Property.scss';
 
 class VectorProperty extends Component {
   constructor(props) {
@@ -105,7 +105,7 @@ class VectorProperty extends Component {
     const stepSize = Math.min(...SteppingValue);
 
     return (
-      <Row className={styles.vectorProperty}>
+      <Row className={`${styles.vectorProperty} ${this.disabled ? styles.disabled : ''}`}>
         <MinMaxRangeInput
           valueMin={values[0]}
           valueMax={values[1]}
@@ -138,7 +138,7 @@ class VectorProperty extends Component {
     }
 
     return (
-      <Row className={styles.vectorProperty}>
+      <Row className={`${styles.vectorProperty} ${this.disabled ? styles.disabled : ''}`}>        
         { values.map((component, index) => (
           <NumericInput
             key={component.key}

--- a/src/components/common/Input/Checkbox/Checkbox.jsx
+++ b/src/components/common/Input/Checkbox/Checkbox.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { excludeKeys } from '../../../../utils/helpers';
 import styles from './Checkbox.scss';
 import MaterialIcon from '../../MaterialIcon/MaterialIcon';
-import Input from '../Input/Input';
 
 class Checkbox extends Component {
   constructor(props) {
@@ -12,6 +11,9 @@ class Checkbox extends Component {
   }
 
   onClick(evt) {
+    if(this.props.disabled) {
+      return;
+    }
     this.props.setChecked(!this.props.checked);
     evt.stopPropagation();
   }
@@ -30,6 +32,7 @@ class Checkbox extends Component {
 
 Checkbox.propTypes = {
   checked: PropTypes.bool,
+  disabled: PropTypes.bool,
   setChecked: PropTypes.func,
   label: PropTypes.node,
   left: PropTypes.bool,

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -27,7 +27,7 @@ class MinMaxRangeInput extends Component {
     this.setRef = this.setRef.bind(this);
     
     this.updateSliderScale = this.updateSliderScale.bind(this);
-    this.scaleValueToSlider = this.scaleValueToSlider.bind(this);
+    this.valueToSliderPos = this.valueToSliderPos.bind(this);
     this.valueFromSliderPos = this.valueFromSliderPos.bind(this);
 
     this.roundValueToStepSize = this.roundValueToStepSize.bind(this);
@@ -82,7 +82,7 @@ class MinMaxRangeInput extends Component {
             .range([min, max]);
   }
 
-  scaleValueToSlider(value) {
+  valueToSliderPos(value) {
     return this.scale.invert(value);
   }
 
@@ -125,8 +125,8 @@ class MinMaxRangeInput extends Component {
 
     // We have to map the value to the slider scale, to get the correct position
     // (note that we don't do this for min and max, as they are the same for any scale)
-    const scaledMinValue = this.scaleValueToSlider(minValue);
-    const scaledMaxValue = this.scaleValueToSlider(maxValue);
+    const scaledMinValue = this.valueToSliderPos(minValue);
+    const scaledMaxValue = this.valueToSliderPos(maxValue);
 
     const normalizedMinValue = (scaledMinValue - min) / (max - min);
     const normalizedMaxValue = (scaledMaxValue - min) / (max - min);
@@ -266,8 +266,8 @@ class MinMaxRangeInput extends Component {
     }
 
     // Scale values for exponential slider
-    const scaledMinValue = this.scaleValueToSlider(minValue);
-    const scaledMaxValue = this.scaleValueToSlider(maxValue);
+    const scaledMinValue = this.valueToSliderPos(minValue);
+    const scaledMaxValue = this.valueToSliderPos(maxValue);
 
     // HoverHint is in [0, 1]. Scale to full range
     const scaledHoverHintOffset = (max - min) * hoverHint + min;

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -365,7 +365,7 @@ MinMaxRangeInput.propTypes = {
   noTooltip: PropTypes.bool,
   onMinValueChanged: PropTypes.func,
   onMaxValueChanged: PropTypes.func,
-  placeholder: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
   step: PropTypes.number,
   wide: PropTypes.bool,
 };
@@ -379,6 +379,7 @@ MinMaxRangeInput.defaultProps = {
   noTooltip: false,
   onMinValueChanged: () => {},
   onMaxValueChanged: () => {},
+  placeholder: 'value',
   step: 1,
   wide: true,
 };

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -83,27 +83,25 @@ class MinMaxRangeInput extends Component {
   }
 
   scaleValueToSlider(value) {
-    return this.scale.invert(value)
+    return this.scale.invert(value);
   }
 
   valueFromSliderPos(sliderValue) {
-    return this.scale(sliderValue)
+    return this.roundValueToStepSize(this.scale(sliderValue));
   }
 
   roundValueToStepSize(value) {
+    // TODO: this should be able to handle any step size.
+    // Now it only deals with exponents of 10
     return round10(value, Math.log10(this.props.step));
   }
 
-  updateMinValue(value) {
-    const newValue = this.roundValueToStepSize(value);
-
+  updateMinValue(newValue) {
     this.setState({ minValue: newValue });
     this.props.onMinValueChanged(newValue);
   }
 
-  updateMaxValue(value) {
-    const newValue = this.roundValueToStepSize(value);
-
+  updateMaxValue(newValue) {
     this.setState({ maxValue: newValue });
     this.props.onMaxValueChanged(newValue);
   }
@@ -274,9 +272,7 @@ class MinMaxRangeInput extends Component {
     // HoverHint is in [0, 1]. Scale to full range
     const scaledHoverHintOffset = (max - min) * hoverHint + min;
 
-    // Round to match the given step size
-    let tooltipValue = this.valueFromSliderPos(scaledHoverHintOffset);
-    tooltipValue = this.roundValueToStepSize(tooltipValue);
+    const tooltipValue = this.valueFromSliderPos(scaledHoverHintOffset);
 
     return (
       <div
@@ -309,7 +305,7 @@ class MinMaxRangeInput extends Component {
           step={step}
           onChange={event => {
             // make sure we don't pass the max slider
-            const sliderValue = Math.min(Number(event.target.value), scaledMaxValue - step);
+            const sliderValue = Math.min(event.currentTarget.value, scaledMaxValue - step);
             const value = this.valueFromSliderPos(sliderValue);
             this.updateMinValue(value);
           }}
@@ -331,7 +327,7 @@ class MinMaxRangeInput extends Component {
           step={step}
           onChange={event => {
             // make sure we don't pass the min slider
-            const sliderValue = Math.max(Number(event.target.value), scaledMinValue + step);
+            const sliderValue = Math.max(event.currentTarget.value, scaledMinValue + step);
             const value = this.valueFromSliderPos(sliderValue);
             this.updateMaxValue(value);
           }}
@@ -342,10 +338,10 @@ class MinMaxRangeInput extends Component {
           { label || placeholder }
         </label>
         <span className={styles.leftValue}>
-          {minValue}
+          { this.roundValueToStepSize(minValue) }
         </span>
         <span className={styles.rightValue}>
-          {maxValue}
+          { this.roundValueToStepSize(maxValue) }
         </span>
       </div>
     );

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -1,0 +1,306 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { excludeKeys } from '../../../../utils/helpers';
+import styles from './MinMaxRangeInput.scss';
+import Input from '../Input/Input';
+import Tooltip from '../../Tooltip/Tooltip';
+import { round10 } from '../../../../utils/rounding';
+import { clamp } from 'lodash/number';
+
+const Scale = require('d3-scale');
+
+class MinMaxRangeInput extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      minValue: props.valueMin,
+      maxValue: props.valueMax,
+      id: `minmaxrangeinput-${Input.nextId}`,
+      hoverHint: null,
+      hoverHintStyle: {}
+    };
+
+    this.setRef = this.setRef.bind(this);
+    
+    this.updateSliderScale = this.updateSliderScale.bind(this);
+    this.scaleValueToSlider = this.scaleValueToSlider.bind(this);
+    this.valueFromSliderPos = this.valueFromSliderPos.bind(this);
+
+    this.roundValueToStepSize = this.roundValueToStepSize.bind(this);
+
+    this.updateMinValue = this.updateMinValue.bind(this);
+    this.updateMaxValue = this.updateMaxValue.bind(this);
+
+    this.onMouseMove = this.onMouseMove.bind(this);
+    this.onLeave = this.onLeave.bind(this);
+
+    this.scale = this.updateSliderScale();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.valueMin !== this.props.valueMin) {
+      this.setState({ minValue: this.props.valueMin });
+    }
+
+    if (prevProps.valueMax !== this.props.valueMax) {
+      this.setState({ maxValue: this.props.valueMax });
+    }
+
+    const scaleNeedsUpdate = (prevProps.min !== this.props.min) ||
+                             (prevProps.max !== this.props.max) ||
+                             (prevProps.exponent !== this.props.exponent);
+
+    if (scaleNeedsUpdate) {
+      this.scale = this.updateSliderScale();
+    }
+  }
+
+  setRef(what) {
+    return (element) => { this[what] = element; };
+  }
+
+  updateSliderScale() {
+    const {exponent, min, max} = this.props;
+
+    // Prevent setting exponent to zero, as it breaks the scale
+    const exp = (exponent == 0) ? 1.0 : exponent;
+
+    // The slider is logarithmic, but the scaling of the value increases exponentially
+    return Scale.scalePow()
+            .exponent(exp)
+            .domain([min, max])
+            .range([min, max]);
+  }
+
+  scaleValueToSlider(value) {
+    return this.scale.invert(value)
+  }
+
+  valueFromSliderPos(sliderValue) {
+    return this.scale(sliderValue)
+  }
+
+  roundValueToStepSize(value) {
+    return round10(value, Math.log10(this.props.step));
+  }
+
+  updateMinValue(newSliderValue) {
+    const valueFromSlider = this.valueFromSliderPos(newSliderValue);
+    const newValue = this.roundValueToStepSize(valueFromSlider);
+
+    this.setState({ minValue: newValue });
+    this.props.onMinValueChanged(newValue);
+  }
+
+  updateMaxValue(newSliderValue) {
+    const valueFromSlider = this.valueFromSliderPos(newSliderValue);
+    const newValue = this.roundValueToStepSize(valueFromSlider);
+
+    this.setState({ maxValue: newValue });
+    this.props.onMaxValueChanged(newValue);
+  }
+
+  onMouseMove(event) {
+    if (this.props.disabled) {
+      return;
+    }
+
+    // Get bounds for input to compute hover percentage
+    const { left, right } = event.currentTarget.getBoundingClientRect();
+    const { clientX } = event;
+    const hoverHint = clamp((clientX - left) / (right - left), 0, 1);
+    this.setState({ hoverHint });
+
+    // Handle other things that depend on mouse position, such as which slider
+    // should be on top and the styling of the hint bar
+
+    const { minValue, maxValue } = this.state;
+    const { min, max } = this.props;
+
+    // We have to map the value to the slider scale, to get the correct position
+    // (note that we don't do this for min and max, as they are the same for any scale)
+    const scaledMinValue = this.scaleValueToSlider(minValue);
+    const scaledMaxValue = this.scaleValueToSlider(maxValue);
+
+    const normalizedMinValue = (scaledMinValue - min) / (max - min);
+    const normalizedMaxValue = (scaledMaxValue - min) / (max - min);
+
+    // Style for hint bar
+    let styleLeft = 0;
+    let styleWidth = 0;
+
+    // TODO: make the hint account for when we have the mouse button down
+
+    const onTop = '4';
+    const onBottom = '3';
+
+    const putRightSliderOnTop = () => {
+      this.maxSlider.style.zIndex = onTop;
+      this.minSlider.style.zIndex = onBottom;
+
+      styleLeft = normalizedMinValue;
+      styleWidth = hoverHint - normalizedMinValue;
+    }
+
+    const putLeftSliderOnTop = () => {
+      this.minSlider.style.zIndex = onTop;
+      this.maxSlider.style.zIndex = onBottom;
+
+      styleLeft = hoverHint;
+      styleWidth = normalizedMaxValue - hoverHint;
+    }
+
+    if (hoverHint < normalizedMinValue) { // mouse < minValue
+      putLeftSliderOnTop();
+    }
+    else if (hoverHint < normalizedMaxValue) { // minValue < mouse < maxValue
+      // Pick the closest handle
+      const leftDistance = hoverHint - normalizedMinValue;
+      const rightDistance = normalizedMaxValue - hoverHint;
+
+      if (leftDistance < rightDistance) { // closer to the left
+        putLeftSliderOnTop();
+      }
+      else { // closer to the right
+        putRightSliderOnTop();
+      }
+    }
+    else { // mouse > maxValue
+      putRightSliderOnTop();
+    }
+
+    const hoverHintStyle = {
+      width: `${100 * styleWidth}%`,
+      left: `${100 * styleLeft}%`
+    }
+
+    this.setState({ hoverHintStyle });
+  }
+
+  onLeave() {
+    this.setState({ hoverHint: null });
+  }
+
+  render() {
+    const { minValue, maxValue, id, hoverHint, hoverHintStyle } = this.state;
+
+    const { placeholder, className, label, wide, min, max, step } = this.props;
+    const doNotInclude = 'wide onMinValueChanged onMaxValueChanged valueMax valueMin ' +
+                         'className type min max step exponent ' +
+                         'label noHoverHint noTooltip';
+    const inheritedProps = excludeKeys(this.props, doNotInclude);
+
+    // Scale values for exponential slider
+    const scaledMinValue = this.scaleValueToSlider(minValue);
+    const scaledMaxValue = this.scaleValueToSlider(maxValue);
+
+    // HoverHint is in [0, 1]. Scale to full range
+    const scaledHoverHintOffset = (max - min) * hoverHint + min;
+
+    // Round to match the given step size
+    let tooltipValue = this.valueFromSliderPos(scaledHoverHintOffset);
+    tooltipValue = this.roundValueToStepSize(tooltipValue);
+
+    return (
+      <div
+        className={`${styles.inputGroup} ${wide ? styles.wide : ''}`}
+      >
+        {!this.props.noHoverHint && hoverHint !== null && (
+          <div className={styles.hoverHint} style={hoverHintStyle} />
+        )} 
+        { !this.props.noTooltip && hoverHint !== null && (
+          <Tooltip style={{ left: `${100 * hoverHint}%` }}>
+            { tooltipValue }
+          </Tooltip>
+        )}
+        <div
+          className={`${className} ${styles.sliderProgress}`}
+          ref={this.setRef('slider')}
+          style={{ '--min': min, '--max': max, '--minValue': scaledMinValue, '--maxValue': scaledMaxValue}}
+        />
+        <input
+          {...inheritedProps}
+          className={`${className} ${styles.range} ${styles.left}`}
+          id={id.concat(" left")}
+          ref={this.setRef('minSlider')}
+          type="range"
+          value={scaledMinValue}
+          min={min}
+          max={max}
+          step={step}
+          onChange={event => {
+            // make sure we don't pass the max slider
+            const value = Math.min(Number(event.target.value), scaledMaxValue - step);
+            this.updateMinValue(value);
+          }}
+          // Put left handle on top on the far right, so it does not get stuck
+          // if both handles are at the rightmost edge
+          style={{ zIndex: minValue > (max - max/10) && "5" }}
+          onMouseMove={this.onMouseMove}
+          onMouseLeave={this.onLeave}
+        />
+        <input
+          {...inheritedProps}
+          className={`${className} ${styles.range} ${styles.right} ${styles.mainSlider}`}
+          id={id.concat(" right")}
+          ref={this.setRef('maxSlider')}
+          type="range"
+          value={scaledMaxValue}
+          min={min}
+          max={max}
+          step={step}
+          onChange={event => {
+            // make sure we don't pass the min slider
+            const value = Math.max(Number(event.target.value), scaledMinValue + step);
+            this.updateMaxValue(value);
+          }}
+          onMouseMove={this.onMouseMove}
+          onMouseLeave={this.onLeave}
+        />
+        <label htmlFor={id} className={`${styles.rangeLabel}`}>
+          { label || placeholder }
+        </label>
+        <span className={styles.leftValue}>
+          {minValue}
+        </span>
+        <span className={styles.rightValue}>
+          {maxValue}
+        </span>
+      </div>
+    );
+  }
+}
+
+MinMaxRangeInput.propTypes = {
+  className: PropTypes.string,
+  disabled: PropTypes.bool,
+  exponent: PropTypes.number,
+  label: PropTypes.node,
+  max: PropTypes.number.isRequired,
+  min: PropTypes.number.isRequired,
+  valueMax: PropTypes.number.isRequired,
+  valueMin: PropTypes.number.isRequired, 
+  noHoverHint: PropTypes.bool,
+  noTooltip: PropTypes.bool,
+  onMinValueChanged: PropTypes.func,
+  onMaxValueChanged: PropTypes.func,
+  placeholder: PropTypes.string.isRequired,
+  step: PropTypes.number,
+  wide: PropTypes.bool,
+};
+
+MinMaxRangeInput.defaultProps = {
+  className: '',
+  disabled: false,
+  exponent: 1.0,
+  label: null,
+  noHoverHint: false,
+  noTooltip: false,
+  onMinValueChanged: () => {},
+  onMaxValueChanged: () => {},
+  step: 1,
+  wide: true,
+};
+
+export default MinMaxRangeInput;

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -109,11 +109,27 @@ class MinMaxRangeInput extends Component {
   }
 
   updateMinValue(newValue) {
+    const { max, min } = this.props;
+
+    if (newValue > max || newValue < min) return;
+
+    if (newValue > this.state.maxValue) {
+      this.updateMaxValue(newValue);
+    }
+
     this.setState({ minValue: newValue });
     this.props.onMinValueChanged(newValue);
   }
 
   updateMaxValue(newValue) {
+    const { max, min } = this.props;
+
+    if (newValue > max || newValue < min) return;
+
+    if (newValue < this.state.minValue) {
+      this.updateMinValue(newValue);
+    }
+
     this.setState({ maxValue: newValue });
     this.props.onMaxValueChanged(newValue);
   }

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -59,6 +59,7 @@ class MinMaxRangeInput extends Component {
 
     const scaleNeedsUpdate = (prevProps.min !== this.props.min) ||
                              (prevProps.max !== this.props.max) ||
+                             (prevProps.step !== this.props.step) ||
                              (prevProps.exponent !== this.props.exponent);
 
     if (scaleNeedsUpdate) {
@@ -143,7 +144,8 @@ class MinMaxRangeInput extends Component {
     let styleLeft = 0;
     let styleWidth = 0;
 
-    // TODO: make the hint account for when we have the mouse button down
+    // @TODO (emmbr, 2021-05-25): potentially make the hint account for when the 
+    // mouse is down, to avoid showing faulty hints when dragging slider handle
 
     const onTop = '4';
     const onBottom = '3';

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
@@ -1,0 +1,124 @@
+@import "../../../../styles/all";
+@import "../Input/Input";
+
+// wrapper element
+.inputGroup {
+  position: relative;
+  box-sizing: border-box;
+  height: $input-total-height;
+}
+
+// the descriptive label
+.rangeLabel {
+  @extend .label;
+  display: block;
+  pointer-events: none;
+
+  > span > span {
+    pointer-events: all;
+  }
+
+  z-index: 4 !important; // same as top slider
+}
+
+// display value
+.leftValue, .rightValue {
+  position: absolute;
+  bottom: $padding-bottom;
+  pointer-events: none;
+}
+
+.leftValue {
+  left: $padding-horizontal;
+}
+
+.rightValue {
+  right: $padding-horizontal;
+}
+
+.wide,
+.wide .inputGroup {
+  width: 100%;
+}
+
+// mouse-tracking hover event
+.hoverHint {
+  background: rgba($blue, 0.3);
+  height: 100%;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+}
+
+// state changes
+.inputGroup {
+  .range:focus + .rangeLabel {
+    color: $green;
+  }
+
+  &:hover {
+    background: $ui-background-active;
+
+    .rangeLabel {
+      color: $text-color-focus;
+    }
+  }
+}
+
+// removing the default appearance
+.range,
+.range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+}
+
+.range {
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  outline: none;
+  margin: 0;
+  background: transparent;
+
+  &:hover {
+    background: transparent;
+  }
+
+  // TODO: make backgrounds behave better
+
+  &.mainSlider {
+    background: $ui-background-hover;
+  }
+
+  // this cannot be completely removed, as that breaks the input.
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    height: 100%;
+    width: 1px;
+    background: transparent;
+  }
+}
+
+.sliderProgress {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+
+  // calculate the width of the background bar using variables set in the component
+  --normalized-minValue: calc(var(--minValue) - var(--min));
+  --normalized-maxValue: calc(var(--maxValue) - var(--min));
+  --diff: calc(var(--normalized-maxValue) - var(--normalized-minValue));
+  --full-width: calc(var(--max) - var(--min));
+  --bg-start: calc(100% * var(--normalized-minValue) / var(--full-width));
+  --bg-stop: calc(100% * var(--diff) / var(--full-width) + var(--bg-start));
+
+    transition: $background-transition;
+    background: linear-gradient(
+      to right,
+      transparent var(--bg-start),
+      $ui-background-hover var(--bg-start) var(--bg-stop),
+      transparent var(--bg-stop)
+    );
+}

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
@@ -84,8 +84,6 @@
     background: transparent;
   }
 
-  // TODO: make backgrounds behave better
-
   &.mainSlider {
     background: $ui-background-hover;
   }

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
@@ -118,7 +118,7 @@
     background: linear-gradient(
       to right,
       transparent var(--bg-start),
-      $ui-background-hover var(--bg-start) var(--bg-stop),
+      $ui-background-slider-input var(--bg-start) var(--bg-stop),
       transparent var(--bg-stop)
     );
 }

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -167,7 +167,7 @@ class NumericInput extends Component {
       );
     }
 
-    const { placeholder, className, label, wide, reverse, min, max, noValue, step } = this.props;
+    const { placeholder, className, label, wide, reverse, noValue } = this.props;
     const doNotInclude = 'wide reverse onValueChanged value className type min max step exponent ' +
                          'inputOnly label noHoverHint noTooltip noValue';
     const inheritedProps = excludeKeys(this.props, doNotInclude);
@@ -211,7 +211,7 @@ class NumericInput extends Component {
           { label || placeholder }
         </label>
         <span className={styles.value}>
-          {noValue ? "" : this.roundValueToStepSize(value)}
+          {noValue ? "" : value}
         </span>
       </div>
     );

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -20,15 +20,17 @@ class NumericInput extends Component {
       hoverHint: null,
     };
 
-    // The slider is logarithmic, but the scaling of the value increases exponentially.
-    // The exponent of the scaling is set based on the max value, to give a reasonable scale
-    // for ranges of different sizes
-    const exp = (Math.abs(props.max) > 1.0) ? Math.log10(props.max) : 1.0;
-    const scale = props.logarithmicScale ? Scale.scalePow().exponent(exp) : Scale.scaleLinear();
-    this.scale = scale.domain([0, 100]).range([props.min, props.max]);
+    // Prevent setting exponent to zero
+    const exp = (props.exponent == 0) ? 1.0 : props.exponent;
 
-    this.sliderMin = scale.domain()[0];
-    this.sliderMax = scale.domain()[1];
+    // The slider is logarithmic, but the scaling of the value increases exponentially
+    this.scale =  Scale.scalePow()
+                    .exponent(exp)
+                    .domain([0, 100])
+                    .range([props.min, props.max]);
+
+    this.sliderMin = this.scale.domain()[0];
+    this.sliderMax = this.scale.domain()[1];
 
     this.onHover = this.onHover.bind(this);
     this.onLeave = this.onLeave.bind(this);
@@ -111,7 +113,7 @@ class NumericInput extends Component {
     if (this.showTextInput) {
       return (
         <Input
-          {...excludeKeys(this.props, 'reverse onValueChanged inputOnly noHoverHint noTooltip logarithmicScale')}
+          {...excludeKeys(this.props, 'reverse onValueChanged inputOnly noHoverHint noTooltip noValue exponent')}
           type="number"
           value={value}
           onBlur={this.onTextBlur}
@@ -122,8 +124,8 @@ class NumericInput extends Component {
     }
 
     const { placeholder, className, label, wide, reverse, min, max, noValue, step } = this.props;
-    const doNotInclude = 'wide reverse onValueChanged value className type min max step ' +
-                         'inputOnly label noHoverHint noTooltip noValue logarithmicScale';
+    const doNotInclude = 'wide reverse onValueChanged value className type min max step exponent ' +
+                         'inputOnly label noHoverHint noTooltip noValue';
     const inheritedProps = excludeKeys(this.props, doNotInclude);
     const hoverHintOffset = reverse ? 1 - hoverHint : hoverHint;
 
@@ -177,9 +179,9 @@ class NumericInput extends Component {
 NumericInput.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
+  exponent: PropTypes.number,
   inputOnly: PropTypes.bool,
   label: PropTypes.node,
-  logarithmicScale: PropTypes.bool,
   max: PropTypes.number,
   min: PropTypes.number,
   reverse: PropTypes.bool,
@@ -196,9 +198,9 @@ NumericInput.propTypes = {
 NumericInput.defaultProps = {
   className: '',
   disabled: false,
+  exponent: 1.0,
   inputOnly: false,
   label: null,
-  logarithmicScale: false,
   max: 100,
   min: 0,
   reverse: false,

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -46,6 +46,7 @@ class NumericInput extends Component {
 
     const scaleNeedsUpdate = (prevProps.min !== this.props.min) ||
                              (prevProps.max !== this.props.max) ||
+                             (prevProps.step !== this.props.step) ||
                              (prevProps.exponent !== this.props.exponent);
 
     if (scaleNeedsUpdate) {

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -198,7 +198,7 @@ class NumericInput extends Component {
           { label || placeholder }
         </label>
         <span className={styles.value}>
-          {noValue ? "" : value}
+          {noValue ? "" : this.roundValueToStepSize(value)}
         </span>
       </div>
     );

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -91,7 +91,9 @@ class NumericInput extends Component {
 
   onTextBlur(event) {
     const value = Number.parseFloat(event.currentTarget.value);
-    this.updateValue(value);
+    if(!isNaN(value)) {
+      this.updateValue(value);
+    }
     this.disableTextInput();
   }
 

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -106,7 +106,7 @@
 
   &::-webkit-slider-runnable-track {
     transition: $background-transition;
-    background: linear-gradient(to right, $ui-background-hover var(--bg-width), transparent var(--bg-width));
+    background: linear-gradient(to right, $ui-background-slider-input var(--bg-width), transparent var(--bg-width));
     height: 100%;
     min-width: 2px;
   }
@@ -114,7 +114,7 @@
 
 .reverse .range::-webkit-slider-runnable-track {
   transition: $background-transition;
-  background: linear-gradient(to left, $ui-background-hover var(--bg-width), transparent var(--bg-width));
+  background: linear-gradient(to left, $ui-background-slider-input var(--bg-width), transparent var(--bg-width));
   height: 100%;
   min-width: 2px;
 }

--- a/src/components/common/Input/Select/Select.jsx
+++ b/src/components/common/Input/Select/Select.jsx
@@ -39,7 +39,7 @@ const selectStyles = {
   }),
   singleValue: (provided, state) => ({
     ...provided,
-    color: '#fff',
+    color: 'inherited',
     paddingTop: 10,
     marginLeft: 0
   })

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -11,6 +11,7 @@ $ui-background: rgba($ui-background-solid, 0.9);
 $ui-background-hover: rgba(white, 0.06);
 $ui-background-selected: rgba(white, 0.03);
 $ui-background-active: rgba(white, 0.03);
+$ui-background-slider-input: rgba(white, 0.1);
 
 $ui-danger: $red;
 $ui-warning: $orange;

--- a/src/utils/rounding.js
+++ b/src/utils/rounding.js
@@ -33,3 +33,42 @@ const decimalAdjust = (type: string, value: number, exponent: ?number = 0): numb
 export const round10 = (value, exponent) => decimalAdjust('round', value, exponent);
 export const floor10 = (value, exponent) => decimalAdjust('floor', value, exponent);
 export const ciel10 = (value, exponent) => decimalAdjust('ciel', value, exponent);
+
+
+/**
+ * Compute the precision of a number. Any value larger than 0 returns
+ * precision 0.
+ * @param value - value to compute precision of
+ */
+export function precision(value: number) {
+  if (!isFinite(value)) return 0;
+
+  var e = 1, precision = 0;
+  while ((Math.round(value * e) / e) !== value) { 
+    e *= 10; precision++; 
+  }
+  return precision;
+}
+
+/**
+ * Round a floating point value to a nice number with a given precision 
+ * (without floating point shenanigans)
+ * https://www.kirupa.com/html5/rounding_numbers_in_javascript.htm
+ * @param value - value to round
+ * @param precision - desired precision of the resulting value
+ */
+export function roundToNiceNumber(value: number, precision: number) {
+    // const p = Math.pow(10, precision(step));
+    const p = Math.pow(10, precision);
+    return Math.round(value * p) / p;
+}
+
+/**
+ * Round a floating point value to a given step size
+ * @param value - value to round
+ * @param value - the step size to round to. Should be smaller than the value
+ */
+export function roundValueToStepSize(value: number, step: number) {
+  const roundedToStep = Math.round(value / step) * step;
+  return roundToNiceNumber(roundedToStep, precision(step));
+}


### PR DESCRIPTION
NumericInput slider updates:
* Make numeric sliders always use exponent of property, instead of having a specific view option
* Numeric sliders can now have any step size (previously limited to exponents of 10)
* Increase contrast of slider bars (now have their own background variable)
* Prevent setting NaN values from text input
* Solve a bug related to slider resolution, that came from the addition of the logarithmic slider and prevented setting the max value sometimes. Sliders now have a fixed resolution, that depends on the number of steps if the slider is linear. 

Also add a dual "min-max range" input slider (for vec2 properties) which also includes all the changes above