### PR TITLE
Settings pane updates

### DIFF
--- a/src/components/Sidebar/Properties/PropertyOwner.jsx
+++ b/src/components/Sidebar/Properties/PropertyOwner.jsx
@@ -2,15 +2,11 @@ import React, { Component, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ToggleContent from '../../common/ToggleContent/ToggleContent';
 import Property from './Property';
-import Button from '../../common/Input/Button/Button';
-import { NavigationAnchorKey, NavigationAimKey, RetargetAnchorKey, LayerGroupKeys } from '../../../api/keys';
-import MaterialIcon from '../../common/MaterialIcon/MaterialIcon';
-import SvgIcon from '../../common/SvgIcon/SvgIcon';
-import FocusIcon from 'svg-react-loader?name=Focus!../../../icons/focus.svg';
-import Shortcut from './../Shortcut';
+import { LayerGroupKeys } from '../../../api/keys';
 import PropertyOwnerHeader from './PropertyOwnerHeader';
 import { setPropertyTreeExpansion, addNodePropertyPopover, addNodeMetaPopover } from '../../../api/Actions';
 import subStateToProps from '../../../utils/subStateToProps';
+import { isPropertyVisible, isPropertyOwnerHidden, isDeadEnd } from './../../../utils/propertyTreeHelpers'
 
 import { connect } from 'react-redux';
 import shallowEqualObjects from 'shallow-equal/objects';
@@ -101,44 +97,6 @@ class PropertyOwnerComponent extends Component {
       }
     </ToggleContent>
   };
-}
-
-const isPropertyOwnerHidden = (properties, uri) => {
-  const prop = properties[uri + '.GuiHidden'];
-  return prop && prop.value;
-}
-
-const isPropertyVisible = (properties, uri) => {
-  const property = properties[uri];
-
-  const splitUri = uri.split('.');
-  if (splitUri.length > 1) {
-    if (splitUri[splitUri.length - 1] === 'Enabled')
-      return false;
-  }
-
-  return property &&
-         property.description &&
-         property.description.MetaData &&
-         property.description.MetaData.Visibility !== 'Hidden';
-}
-
-const isDeadEnd = (propertyOwners, properties, uri) => {
-  const node = propertyOwners[uri];
-  const subowners = node.subowners || [];
-  const subproperties = node.properties || [];
-
-  const visibleProperties = subproperties.filter(
-    childUri => isPropertyVisible(properties, childUri)
-  );
-  if (visibleProperties.length > 0) {
-    return false;
-  }
-
-  const nonDeadEndSubowners = subowners.filter(childUri => {
-    return !isPropertyOwnerHidden(properties, childUri) && !isDeadEnd(propertyOwners, properties, childUri);
-  });
-  return nonDeadEndSubowners.length === 0;
 }
 
 const shouldSortAlphabetically = uri => {

--- a/src/components/Sidebar/ScenePaneListItem.jsx
+++ b/src/components/Sidebar/ScenePaneListItem.jsx
@@ -29,8 +29,6 @@ class ScenePaneListItem extends Component {
     }
     return null;
   }
-
-
 }
 
 export default ScenePaneListItem;

--- a/src/components/Sidebar/SettingsPane.jsx
+++ b/src/components/Sidebar/SettingsPane.jsx
@@ -6,6 +6,7 @@ import LoadingBlocks from '../common/LoadingBlock/LoadingBlocks';
 import FilterList from '../common/FilterList/FilterList';
 import PropertyOwner from './Properties/PropertyOwner';
 import { SceneKey } from '../../api/keys';
+import subStateToProps from '../../utils/subStateToProps';
 
 import styles from './SettingsPane.scss';
 
@@ -43,28 +44,29 @@ SettingsPane.defaultProps = {
   closeCallback: null,
 };
 
-const mapStateToProps = (state) => {
+const mapStateToSubState = (state) => ({
+  properties: state.propertyTree.properties,
+  propertyOwners: state.propertyTree.propertyOwners
+});
 
-  if (!state.propertyTree) {
+const mapSubStateToProps = ({ properties, propertyOwners }) => {
+  if (!propertyOwners || !properties) {
     return { entries: [] };
   }
-  if (!state.propertyTree.propertyOwners) {
-    return { entries: [] };
-  }
 
-  const allUris = Object.keys(state.propertyTree.propertyOwners || {});
+  const allUris = Object.keys(propertyOwners || {});
 
-  const propertyOwners = allUris.filter(uri => {
+  const propertyOwnerUris = allUris.filter(uri => {
     return uri !== SceneKey && uri.indexOf('.') === -1;
   });
 
   return {
-    propertyOwners,
+    propertyOwners: propertyOwnerUris,
   };
 };
 
 SettingsPane = connect(
-  mapStateToProps,
+  subStateToProps(mapSubStateToProps, mapStateToSubState)
 )(SettingsPane);
 
 export default SettingsPane;

--- a/src/components/Sidebar/SettingsPane.jsx
+++ b/src/components/Sidebar/SettingsPane.jsx
@@ -4,9 +4,11 @@ import PropTypes from 'prop-types';
 import Pane from './Pane';
 import LoadingBlocks from '../common/LoadingBlock/LoadingBlocks';
 import FilterList from '../common/FilterList/FilterList';
-import PropertyOwner from './Properties/PropertyOwner';
 import { SceneKey } from '../../api/keys';
 import subStateToProps from '../../utils/subStateToProps';
+import { CaseInsensitiveSubstring, ListCaseInsensitiveSubstring } from '../../utils/StringMatchers';
+import SettingsPaneListItem from './SettingsPaneListItem';
+import { getLastWordOfUri, isPropertyVisible, isPropertyOwnerHidden, isDeadEnd } from './../../utils/propertyTreeHelpers'
 
 import styles from './SettingsPane.scss';
 
@@ -16,20 +18,62 @@ class SettingsPane extends Component {
   }
 
   render() {
-    const entries = this.props.propertyOwners.map(uri => ({
-      key: uri,
-      uri: uri,
-      expansionIdentifier: uri
+    const defaultEntries = this.props.topPropertyOwners.map(p => ({
+      key: p.uri,
+      uri: p.uri,
+      name: p.name,
+      type: 'propertyOwner',
+      expansionIdentifier: p.uri
     }));
+
+    const searchEntries = defaultEntries
+      .concat(this.props.subPropertyOwners.map(p => ({
+        key: p.uri,
+        uri: p.uri,
+        name: p.name,
+        type: 'subPropertyOwner',
+        expansionIdentifier: p.uri
+      }))
+      .concat(this.props.properties.map(p => ({
+        key: p.uri,
+        uri: p.uri,
+        names: p.names,
+        type: 'property'
+      }))
+    ));
+
+    const matcher = (entry, searchString) => {
+      searchString = searchString.trim();
+
+      if(!searchString) {
+        return false; // guard against empty strings
+      }
+
+      if (entry.type === 'propertyOwner') {
+        return CaseInsensitiveSubstring(entry.uri, searchString);
+      }
+      if (entry.type === 'subPropertyOwner') {
+        return CaseInsensitiveSubstring(entry.name, searchString);
+      }
+      if (entry.type === 'property') {
+        return ListCaseInsensitiveSubstring(entry.names, searchString);
+      }
+    };
 
     return (
       <Pane title="Settings" closeCallback={this.props.closeCallback}>
-        { (entries.length === 0) && (
+        { (defaultEntries.length === 0) && (
           <LoadingBlocks className={Pane.styles.loading} />
         )}
 
-        {(entries.length > 0) && (
-          <FilterList data={entries} viewComponent={PropertyOwner} searchAutoFocus />
+        {(defaultEntries.length > 0) && (
+          <FilterList
+            favorites={defaultEntries}
+            data={searchEntries}
+            viewComponent={SettingsPaneListItem}
+            matcher={matcher}
+            searchAutoFocus
+          />
         )}
       </Pane>
     );
@@ -46,22 +90,70 @@ SettingsPane.defaultProps = {
 
 const mapStateToSubState = (state) => ({
   properties: state.propertyTree.properties,
-  propertyOwners: state.propertyTree.propertyOwners
+  propertyOwners: state.propertyTree.propertyOwners,
+  propertyTree: state.propertyTree
 });
 
-const mapSubStateToProps = ({ properties, propertyOwners }) => {
-  if (!propertyOwners || !properties) {
-    return { entries: [] };
+const mapSubStateToProps = ({ properties, propertyOwners, propertyTree }) => {
+  if (!propertyTree || !propertyOwners || !properties ) {
+    return { };
   }
 
-  const allUris = Object.keys(propertyOwners || {});
-
-  const propertyOwnerUris = allUris.filter(uri => {
+  const allOwnerUris = Object.keys(propertyOwners || {});
+  const nonSceneTopPropertyOwners = allOwnerUris.filter(uri => {
     return uri !== SceneKey && uri.indexOf('.') === -1;
   });
 
+  const collectUrisRecursively = (owners, collectedOwners, collectedProperties) => {
+    owners.forEach(uri => {
+      let subowners = propertyOwners[uri].subowners || {};
+      let properties = propertyOwners[uri].properties || {};
+      collectedOwners = collectedOwners.concat(subowners);
+      collectedProperties = collectedProperties.concat(properties);
+
+      [collectedOwners, collectedProperties] = collectUrisRecursively(
+        subowners, collectedOwners, collectedProperties);
+    });
+
+    // Stops when owners are empty
+    return [ collectedOwners, collectedProperties ];
+  }
+  
+  // Collect uris of all sub property owners and properties
+  let subPropertyOwners = [];
+  let searchableProperties = [];
+  [subPropertyOwners, searchableProperties] = collectUrisRecursively(
+    nonSceneTopPropertyOwners,
+    subPropertyOwners,
+    searchableProperties
+  );
+
+  // Remove any hidden owners/properties
+  subPropertyOwners = subPropertyOwners.filter(uri => {
+    return (!isPropertyOwnerHidden(properties, uri) && 
+      !isDeadEnd(propertyOwners, properties, uri));
+  });
+  searchableProperties = searchableProperties.filter(uri => {
+    return isPropertyVisible(properties, uri);
+  });
+
+  // Compose the information we need for the search
+  const topOwnersInfo = nonSceneTopPropertyOwners.map(uri => {
+    return { uri: uri, name: getLastWordOfUri(uri) };
+  });
+
+  const subPropertyOwnersInfo = subPropertyOwners.map(uri => {
+    return { uri: uri, name: getLastWordOfUri(uri) };
+  });
+
+  const propertiesInfo = searchableProperties.map(uri => {
+    return { uri: uri, names:[getLastWordOfUri(uri), properties[uri].description.Name] };
+  });
+
   return {
-    propertyOwners: propertyOwnerUris,
+    topPropertyOwners: topOwnersInfo,
+    subPropertyOwners: subPropertyOwnersInfo,
+    properties: propertiesInfo
   };
 };
 

--- a/src/components/Sidebar/SettingsPaneListItem.jsx
+++ b/src/components/Sidebar/SettingsPaneListItem.jsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import PropertyOwner from './Properties/PropertyOwner';
+import Property from './Properties/Property';
+import { removeLastWordFromUri } from '../../utils/propertyTreeHelpers'
+
+import styles from './SettingsPaneListItem.scss';
+
+class SettingsPaneListItem extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const props = this.props;
+
+    if (props.type === 'subPropertyOwner') {
+      return (
+        <div className={styles.propertyItemGroup}>
+          <p>{removeLastWordFromUri(this.props.uri)}</p>
+          <PropertyOwner
+              uri={this.props.uri}
+              expansionIdentifier={'scene-search/' + this.props.uri} />
+        </div>
+      );
+    }
+    if (props.type === 'propertyOwner') {
+      return <PropertyOwner
+              uri={this.props.uri}
+              expansionIdentifier={'scene-search/' + this.props.uri} />
+    }
+    if (props.type === 'property') {
+      return (
+        <div className={styles.propertyItemGroup}>
+          <p>{removeLastWordFromUri(this.props.uri)}</p>
+          <Property index={this.props.index} key={this.props.uri} uri={this.props.uri}/>
+        </div>
+      );
+    }
+    return null;
+  }
+}
+
+export default SettingsPaneListItem;

--- a/src/components/Sidebar/SettingsPaneListItem.scss
+++ b/src/components/Sidebar/SettingsPaneListItem.scss
@@ -1,0 +1,18 @@
+@import "../../styles/all.scss";
+
+.propertyItemGroup {
+  margin-left: 0.3rem;
+  padding: 0.2rem;
+  padding-bottom: 0.35rem;
+
+  p {
+    font-size: 0.9rem;
+    color: darken($text-color-focus, 30%);
+
+    // Little ugly hack to reduce the top padding of the related setting
+    // and hence put it closer to the text
+    & + div {
+      padding-top: 3px !important;
+    }
+  }
+}

--- a/src/utils/StringMatchers.js
+++ b/src/utils/StringMatchers.js
@@ -9,6 +9,12 @@
 export const SimpleSubstring = (test: string, search: string): bool =>
   test.includes(search);
 
+export const CaseInsensitiveSubstring = (test: string, search: string): bool => {
+  const lowerCaseTest = test.toLowerCase();
+  const lowerCaseSearch = search.toLowerCase();
+  return lowerCaseTest.includes(lowerCaseSearch);
+};
+
 export const WordBeginningSubstring = (test: string, search: string): bool => {
   const searchWords = search.split(" ");
   const testWords = test.split(" ");
@@ -37,4 +43,16 @@ export const ObjectWordBeginningSubstring = (test: object, search: string): bool
     .map(t => t.toString())
     .map(t => t.toLowerCase());
   return valuesAsStrings.some(test => WordBeginningSubstring(test, search));
+};
+
+/**
+ * Check if search is a substring of any of the strings in the list
+ * @param test - string list to match against
+ * @param search - string to match with
+ * @constructor
+ */
+export const ListCaseInsensitiveSubstring = (test: string[], search: string): bool => {
+  const lowerCaseTest = test.map(t => t.toLowerCase());
+  const lowerCaseSearch = search.toLowerCase();
+  return lowerCaseTest.some(t => t.includes(lowerCaseSearch));
 };


### PR DESCRIPTION
Search bar now searches property owners (including subowners) and properties

To distinguish between results, a label with the parents is included on top of each match (see image). Now each item has a label, but later on we should combine sibling properties into one group and avoid repeating the header multiple times (for example `Modules.Server.Interfaces` in the image could be on one group)

![image](https://user-images.githubusercontent.com/8808894/119716936-fb2df700-be65-11eb-8f60-72c51abeff7e.png)
