### PR TITLE
Issue/1908 - 

### DIFF
--- a/src/api/Middleware/exoplanets.js
+++ b/src/api/Middleware/exoplanets.js
@@ -7,8 +7,12 @@ import api from '../api';
 import { actionTypes } from '../Actions/actionTypes';
 
 const getExoplanets = async (luaApi, callback) => {
-  var planetList = await luaApi.exoplanets.getListOfExoplanets();
-  var listArray = Object.values(planetList[1])
+  let planetList = await luaApi.exoplanets.getListOfExoplanets();
+  let actualList = planetList[1];
+  if (!actualList) {
+    return;
+  }
+  var listArray = Object.values(actualList)
   listArray = listArray.map(item => {
     return {"name": item, "identifier": item};
   })
@@ -31,8 +35,7 @@ export const exoplanets = store => next => (action) => {
       });
       break;
     case actionTypes.removeExoplanets:
-      removeSystem(action.payload.system, () => {
-      })
+      removeSystem(action.payload.system, () => {})
       break;
     default:
       break;

--- a/src/api/keys.js
+++ b/src/api/keys.js
@@ -59,6 +59,8 @@ export const SessionStateRecording = 'recording';
 export const SessionStatePlaying = 'playing';
 export const SessionStatePaused = 'playing-paused';
 
+export const ExoplanetsModuleEnabledKey = 'Modules.Exoplanets.Enabled';
+
 // renderableTypes
 export const RenderableTypes = {
   // RenderableAtmosphere: "RenderableAtmosphere",


### PR DESCRIPTION
This is a draft PR containing a check to not show the exoplanets panel if exoplanets module is disabled

TODO:
- [] Do the same thing for skybrowser, once that is merged
- [] Show panel is exoplanets panel is enabled, even if there is no data (now it's hidden if there are no systems)