### PR TITLE
Only display properties that match the settings for the visibility in…

### DIFF
--- a/src/components/Sidebar/Properties/PropertyOwner.jsx
+++ b/src/components/Sidebar/Properties/PropertyOwner.jsx
@@ -187,13 +187,14 @@ class PropertyOwnerComponent extends Component {
       setExpanded,
       expansionIdentifier,
       sort,
+      isHidden
     } = this.props;
 
     const sortedSubowners = sort
       ? (subowners.slice(0).sort((a, b) => subownerNames[a].localeCompare(subownerNames[b], 'en')))
       : subowners;
 
-    return (
+    return !isHidden && (
       <ToggleContent
         header={this.header}
         expanded={isExpanded}
@@ -251,6 +252,8 @@ const mapSubStateToProps = (
   },
 ) => {
   const data = propertyOwners[uri];
+  const showHidden = properties['Modules.CefWebGui.ShowHiddenSceneGraphNodes'];
+  let isHidden = isPropertyOwnerHidden(properties, uri) && !showHidden.value;
   let subowners = data ? data.subowners : [];
   let subProperties = data ? data.properties : [];
 
@@ -291,6 +294,7 @@ const mapSubStateToProps = (
     sort,
     isRenderable: (renderableTypeProp != undefined),
     isSceneGraphNodeOrLayer: showMeta,
+    isHidden
   };
 };
 

--- a/src/components/Sidebar/Properties/PropertyOwner.jsx
+++ b/src/components/Sidebar/Properties/PropertyOwner.jsx
@@ -252,7 +252,7 @@ const mapSubStateToProps = (
   },
 ) => {
   const data = propertyOwners[uri];
-  const showHidden = properties['Modules.CefWebGui.ShowHiddenSceneGraphNodes'];
+  const showHidden = properties['OpenSpaceEngine.ShowHiddenSceneGraphNodes'];
   let isHidden = isPropertyOwnerHidden(properties, uri) && !showHidden.value;
   let subowners = data ? data.subowners : [];
   let subProperties = data ? data.properties : [];

--- a/src/components/Sidebar/ScenePane.jsx
+++ b/src/components/Sidebar/ScenePane.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { isPropertyOwnerHidden } from './../../utils/propertyTreeHelpers';
 import { ObjectWordBeginningSubstring } from '../../utils/StringMatchers';
 import subStateToProps from '../../utils/subStateToProps';
 import FilterList from '../common/FilterList/FilterList';
@@ -99,8 +98,7 @@ const mapSubStateToProps = ({ groups, properties, propertyOwners }) => {
   const matcher = (test, search) => {
     if (test.type === 'propertyOwner') {
       const node = propertyOwners[test.uri] || {};
-      const guiHidden = isPropertyOwnerHidden(properties, test.uri);
-      return ObjectWordBeginningSubstring(node, search) && !guiHidden;
+      return ObjectWordBeginningSubstring(node, search);
     }
     return false;
   };

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -113,45 +113,40 @@ export function removeLastWordFromUri(uri) {
 export function isPropertyVisible(properties, uri) {
   const property = properties[uri];
   const visibility = properties['OpenSpaceEngine.PropertyVisibility'];
-
+  if (!property?.description?.MetaData?.Visibility) {
+    return false;
+  }
+  // Don't show the property "Enabled"
   const splitUri = uri.split('.');
-  if (splitUri.length > 1) {
-    if (splitUri[splitUri.length - 1] === 'Enabled')
+  if (splitUri.length > 1 && splitUri[splitUri.length - 1] === 'Enabled') {
       return false;
   }
 
-  if (property && property.description && property.description.MetaData &&
-      property.description.MetaData.Visibility) {
-    let propertyVisibility = "";
-    switch(property.description.MetaData.Visibility) {
-      case 'Hidden':
-        propertyVisibility = 5;
-        break;
-      case 'Developer':
-        propertyVisibility = 4;
-        break;
-      case 'AdvancedUser':
-        propertyVisibility = 3;
-        break;
-      case 'User':
-        propertyVisibility = 2;
-        break;
-      case 'NoviceUser':
-        propertyVisibility = 1;
-        break;
-      case 'Always':
-        propertyVisibility = 0;
-        break;
-      default:
-        propertyVisibility = 0;
-        break;
-    }
-
-    return visibility.value >= propertyVisibility;
+  let propertyVisibility = "";
+  switch (property.description.MetaData.Visibility) {
+    case 'Hidden':
+      propertyVisibility = 5;
+      break;
+    case 'Developer':
+      propertyVisibility = 4;
+      break;
+    case 'AdvancedUser':
+      propertyVisibility = 3;
+      break;
+    case 'User':
+      propertyVisibility = 2;
+      break;
+    case 'NoviceUser':
+      propertyVisibility = 1;
+      break;
+    case 'Always':
+      propertyVisibility = 0;
+      break;
+    default:
+      propertyVisibility = 0;
+      break;
   }
-  else {
-    return false;
-  }
+  return visibility.value >= propertyVisibility;
 }
 
 // Returns whether a property owner should be hidden in the gui

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -112,7 +112,7 @@ export function removeLastWordFromUri(uri) {
 // Returns whether a property should be visible in the gui
 export function isPropertyVisible(properties, uri) {
   const property = properties[uri];
-  const visibility = properties['Modules.CefWebGui.Visibility'];
+  const visibility = properties['OpenSpaceEngine.Visibility'];
 
   const splitUri = uri.split('.');
   if (splitUri.length > 1) {

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -112,6 +112,7 @@ export function removeLastWordFromUri(uri) {
 // Returns whether a property should be visible in the gui
 export function isPropertyVisible(properties, uri) {
   const property = properties[uri];
+  const visibility = properties['Modules.CefWebGui.Visibility'];
 
   const splitUri = uri.split('.');
   if (splitUri.length > 1) {
@@ -119,10 +120,31 @@ export function isPropertyVisible(properties, uri) {
       return false;
   }
 
-  return property &&
-         property.description &&
-         property.description.MetaData &&
-         property.description.MetaData.Visibility !== 'Hidden';
+  if (property && property.description && property.description.MetaData &&
+      property.description.MetaData.Visibility) {
+    let propertyVisibility = "";
+    switch(property.description.MetaData.Visibility) {
+      case 'Hidden':
+        propertyVisibility = 3;
+        break;
+      case 'Developer':
+        propertyVisibility = 2;
+        break;
+      case 'User':
+        propertyVisibility = 1;
+        break;
+      case 'All':
+        propertyVisibility = 0;
+        break;
+      default:
+        propertyVisibility = 0;
+        break;
+    }
+    return visibility.value >= propertyVisibility;
+  }
+  else {
+    return false;
+  }
 }
 
 // Returns whether a property owner should be hidden in the gui

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -149,8 +149,12 @@ export function isPropertyVisible(properties, uri) {
 
 // Returns whether a property owner should be hidden in the gui
 export function isPropertyOwnerHidden(properties, uri) {
+  if (uri === undefined) return false;
   const prop = properties[uri + '.GuiHidden'];
-  return prop && prop.value;
+  if(prop && prop.value) {
+    return true;
+  }
+  else return false;
 }
 
 // Returns true if a property owner has no visible children

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -125,15 +125,15 @@ export function isPropertyVisible(properties, uri) {
     let propertyVisibility = "";
     switch(property.description.MetaData.Visibility) {
       case 'Hidden':
-        propertyVisibility = 3;
+        propertyVisibility = 4;
         break;
       case 'Developer':
-        propertyVisibility = 2;
+        propertyVisibility = 3;
         break;
       case 'User':
         propertyVisibility = 1;
         break;
-      case 'All':
+      case 'Always':
         propertyVisibility = 0;
         break;
       default:

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -112,7 +112,7 @@ export function removeLastWordFromUri(uri) {
 // Returns whether a property should be visible in the gui
 export function isPropertyVisible(properties, uri) {
   const property = properties[uri];
-  const visibility = properties['OpenSpaceEngine.Visibility'];
+  const visibility = properties['OpenSpaceEngine.PropertyVisibility'];
 
   const splitUri = uri.split('.');
   if (splitUri.length > 1) {

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -125,12 +125,18 @@ export function isPropertyVisible(properties, uri) {
     let propertyVisibility = "";
     switch(property.description.MetaData.Visibility) {
       case 'Hidden':
-        propertyVisibility = 4;
+        propertyVisibility = 5;
         break;
       case 'Developer':
+        propertyVisibility = 4;
+        break;
+      case 'AdvancedUser':
         propertyVisibility = 3;
         break;
       case 'User':
+        propertyVisibility = 2;
+        break;
+      case 'NoviceUser':
         propertyVisibility = 1;
         break;
       case 'Always':
@@ -140,6 +146,7 @@ export function isPropertyVisible(properties, uri) {
         propertyVisibility = 0;
         break;
     }
+
     return visibility.value >= propertyVisibility;
   }
   else {


### PR DESCRIPTION
… the CEFWebGui

This checks the visibility of the property before it is rendered in the GUI.