### PR TITLE
Feature/actions updates

### DIFF
--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -133,7 +133,7 @@ class ActionsPanel extends Component {
           <Row>
             {backButton}
             <div className={styles.navPathTitle}>
-              {` ${navPathString} `}
+              {`${this.props.displayedNavigationPath}`}
             </div>
           </Row>
         <hr className={Popover.styles.delimiter} />
@@ -198,7 +198,7 @@ class ActionsPanel extends Component {
           <Row>
             {backButton}
             <div className={styles.navPathTitle}>
-              {` ${navPathString} `}
+              {`${this.props.displayedNavigationPath}`}
             </div>
           </Row>
           <hr className={Popover.styles.delimiter} />
@@ -248,6 +248,7 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
       popoverVisible,
       luaApi,
       navigationPath: '/',
+      displayedNavigationPath: '/'
     };
   }
 
@@ -312,11 +313,31 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
     }
   });
 
+  // Truncate navigation path if too long
+  const NAVPATH_LENGTH_LIMIT = 60;
+  const shouldTruncate = actions.navigationPath.length > NAVPATH_LENGTH_LIMIT;
+
+  let truncatedPath = actions.navigationPath;
+  if (shouldTruncate) {
+    let originalPath = navPath;
+    if (originalPath[0] === '/') {
+      originalPath = originalPath.substring(1);
+    }
+    let pieces = originalPath.split('/');
+    if (pieces.length > 1) {
+      // TODO: maybe keep more pieces of the path, if possible?
+      truncatedPath = `/${pieces[0]}/.../${pieces[pieces.length - 1]}`;
+    } else {
+      truncatedPath = navPath.substring(0, NAVPATH_LENGTH_LIMIT);
+    }
+  }
+
   return {
     actionLevel: actionsForPath,
     popoverVisible,
     luaApi,
     navigationPath: actions.navigationPath,
+    displayedNavigationPath: truncatedPath,
     allActions: allActions,
   };
 };

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -106,8 +106,8 @@ class ActionsPanel extends Component {
 
   getBackButton() {
     if (this.props.navigationPath != '/') {
-      return <Button block smalltext className={styles.backButton} onClick={this.goBack} key="backbtn">
-        <MaterialIcon className={styles.buttonIcon} icon="arrow_back" /> Back
+      return <Button block className={styles.backButton} onClick={this.goBack} key="backbtn">
+        <MaterialIcon className={styles.buttonIcon} icon="arrow_back" />
       </Button>;
     }
   }

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -131,13 +131,12 @@ class ActionsPanel extends Component {
       <div id="actionscroller" className={`${styles.windowContainer}`}>
         <hr className={Popover.styles.delimiter} />
           <Row>
-            <div className={Popover.styles.title}>
-              {navPathString}
-              {' '}
+            {backButton}
+            <div className={styles.navPathTitle}>
+              {` ${navPathString} `}
             </div>
           </Row>
         <hr className={Popover.styles.delimiter} />
-        {backButton}
         <FilterList matcher={this.matcher} height={'80%'}>
           <FilterListFavorites className={styles.Grid}>
             {actionsContent}
@@ -197,9 +196,8 @@ class ActionsPanel extends Component {
           <hr className={Popover.styles.delimiter} />
           <Row>
             {backButton}
-            <div style={{ whiteSpace: 'nowrap' }} className={Popover.styles.title}>
-              {navPathString}
-              {' '}
+            <div className={styles.navPathTitle}>
+              {` ${navPathString} `}
             </div>
           </Row>
           <hr className={Popover.styles.delimiter} />

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -175,7 +175,7 @@ class ActionsPanel extends Component {
       >
         <div id="actionscroller" className={`${Popover.styles.content}`}>
           <hr className={Popover.styles.delimiter} />
-          <Row>
+          <Row className={styles.navPathRow}>
             {backButton}
             <div className={styles.navPathTitle}>
               {`${this.props.displayedNavigationPath}`}

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -257,6 +257,12 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
     if (action.key) {
       continue;
     }
+
+    // If there is no backslack at beginning of GUI path, add that manually
+    if (action.guiPath.length > 0 && action.guiPath[0] !== '/') {
+      action.guiPath = '/' + action.guiPath;
+    }
+
     var splits = action.guiPath.split('/');
     splits.shift();
     let parent = actionsMapped['/'];

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -31,8 +31,9 @@ class ActionsPanel extends Component {
   }
 
   addNavPath(e) {
-    let navString = this.props.navigationPath;
-    if (this.props.navigationPath == '/') {
+    const { navigationPath } = this.props;
+    let navString = navigationPath;
+    if (navigationPath == '/') {
       navString += e.currentTarget.getAttribute('foldername');
     } else {
       navString += `/${e.currentTarget.getAttribute('foldername')}`;
@@ -41,7 +42,8 @@ class ActionsPanel extends Component {
   }
 
   goBack(e) {
-    let navString = this.props.navigationPath;
+    const { navigationPath } = this.props;
+    let navString = navigationPath;
     navString = navString.substring(0, navString.lastIndexOf('/'));
     if (navString.length == 0) {
       navString = '/';
@@ -50,8 +52,9 @@ class ActionsPanel extends Component {
   }
 
   sendAction(e) {
+    const { luaApi } = this.props;
     const actionId = e.currentTarget.getAttribute('actionid');
-    this.props.luaApi.action.triggerAction(actionId);
+    luaApi.action.triggerAction(actionId);
   }
 
   getActionContent(level) {
@@ -88,7 +91,8 @@ class ActionsPanel extends Component {
   }
 
   getAllActions() {
-    return this.props.allActions.map((action) => (
+    const { allActions } = this.props;
+    return allActions.map((action) => (
       <Button
         block
         smalltext
@@ -105,7 +109,8 @@ class ActionsPanel extends Component {
   }
 
   getBackButton() {
-    if (this.props.navigationPath != '/') {
+    const { navigationPath } = this.props;
+    if (navigationPath != '/') {
       return <Button block className={styles.backButton} onClick={this.goBack} key="backbtn">
         <MaterialIcon className={styles.buttonIcon} icon="arrow_back" />
       </Button>;
@@ -117,7 +122,7 @@ class ActionsPanel extends Component {
   }
 
   get windowContent() {
-    const level = this.props.actionLevel;
+    const { displayedNavigationPath, level } = this.props;
 
     if (level == undefined) {
       return <div>Loading</div>;
@@ -125,7 +130,6 @@ class ActionsPanel extends Component {
     const actionsContent = this.getActionContent(level);
     const childrenContent = this.getChildrenContent(level);
     const backButton = this.getBackButton();
-    const navPathString = this.props.navigationPath;
     
     return (
       <div id="actionscroller" className={`${styles.windowContainer}`}>
@@ -133,7 +137,7 @@ class ActionsPanel extends Component {
           <Row>
             {backButton}
             <div className={styles.navPathTitle}>
-              {`${this.props.displayedNavigationPath}`}
+              {`${displayedNavigationPath}`}
             </div>
           </Row>
         <hr className={Popover.styles.delimiter} />
@@ -151,15 +155,16 @@ class ActionsPanel extends Component {
   }
 
   get popover() {
+    const { actionLevel, displayedNavigationPath } = this.props;
     let actionsContent;
     let childrenContent;
     let backButton;
 
-    if (this.props.actionLevel.length == 0) {
+    if (actionLevel.length == 0) {
       actionsContent = <div>No Actions</div>;
       childrenContent = <div>No Children</div>;
     } else {
-      const level = this.props.actionLevel;
+      const level = actionLevel;
       actionsContent = this.getActionContent(level);
       childrenContent = this.getChildrenContent(level);
       backButton = this.getBackButton();
@@ -178,7 +183,7 @@ class ActionsPanel extends Component {
           <Row className={styles.navPathRow}>
             {backButton}
             <div className={styles.navPathTitle}>
-              {`${this.props.displayedNavigationPath}`}
+              {`${displayedNavigationPath}`}
             </div>
           </Row>
           <hr className={Popover.styles.delimiter} />
@@ -236,7 +241,7 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
       continue;
     }
 
-    // If there is no backslack at beginning of GUI path, add that manually
+    // If there is no backslach at beginning of GUI path, add that manually
     if (action.guiPath.length > 0 && action.guiPath[0] !== '/') {
       action.guiPath = '/' + action.guiPath;
     }

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -66,7 +66,7 @@ class ActionsPanel extends Component {
       >
         <p><MaterialIcon className={styles.buttonIcon} icon="launch" /></p>
         {action.name}
-        <InfoBox text={action.documentation} />
+        {action.documentation && <InfoBox text={action.documentation} />}
       </Button>
     ));
   }

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -169,6 +169,7 @@ class ActionsPanel extends Component {
     const navPathString = this.props.navigationPath;
 
     if (navPathString == '/') {
+      // Special button to show keybindings (opens keyboard view)
       keybindsContent = (
         <Button
           block
@@ -203,8 +204,8 @@ class ActionsPanel extends Component {
           <hr className={Popover.styles.delimiter} />
           <FilterList matcher={this.matcher} height={backButton ? '280px' : '320px'}>
             <FilterListFavorites className={styles.Grid}>
-              {actionsContent}
               {childrenContent}
+              {actionsContent}
               {keybindsContent}
             </FilterListFavorites>
             <FilterListData className={styles.Grid}>
@@ -264,6 +265,13 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
     var splits = action.guiPath.split('/');
     splits.shift();
     let parent = actionsMapped['/'];
+
+    // Add to top level actions (no gui path)
+    if (splits.length == 0) {
+      parent.actions.push(action);
+    }
+
+    // Add actions of other levels
     while (splits.length > 0) {
       var index = splits.shift();
       if (parent.children[index] == undefined) {

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -154,7 +154,6 @@ class ActionsPanel extends Component {
     let actionsContent;
     let childrenContent;
     let backButton;
-    let keybindsContent;
 
     if (this.props.actionLevel.length == 0) {
       actionsContent = <div>No Actions</div>;
@@ -164,25 +163,6 @@ class ActionsPanel extends Component {
       actionsContent = this.getActionContent(level);
       childrenContent = this.getChildrenContent(level);
       backButton = this.getBackButton();
-    }
-
-    const navPathString = this.props.navigationPath;
-
-    if (navPathString == '/') {
-      // Special button to show keybindings (opens keyboard view)
-      keybindsContent = (
-        <Button
-          block
-          smalltext
-          onClick={this.props.toggleKeybinds}
-          key="showKeybinds"
-          className={styles.actionButton}
-        >
-          <p><MaterialIcon className={styles.buttonIcon} icon="keyboard" /></p>
-          Show Keybindings
-          <InfoBox text="Shows the keybinding viewer" />
-        </Button>
-      );
     }
 
     return (
@@ -206,11 +186,9 @@ class ActionsPanel extends Component {
             <FilterListFavorites className={styles.Grid}>
               {childrenContent}
               {actionsContent}
-              {keybindsContent}
             </FilterListFavorites>
             <FilterListData className={styles.Grid}>
               {this.getAllActions()}
-              {keybindsContent}
             </FilterListData>
           </FilterList>
         </div>
@@ -360,12 +338,6 @@ const mapDispatchToProps = (dispatch) => ({
   },
   actionPath: (action) => {
     dispatch(setActionsPath(action));
-  },
-  toggleKeybinds: (action) => {
-    dispatch(setPopoverVisibility({
-      popover: 'keybinds',
-      visible: true,
-    }));
   },
 });
 

--- a/src/components/BottomBar/ActionsPanel.jsx
+++ b/src/components/BottomBar/ActionsPanel.jsx
@@ -106,7 +106,9 @@ class ActionsPanel extends Component {
 
   getBackButton() {
     if (this.props.navigationPath != '/') {
-      return <Button block smalltext className={styles.backButton} onClick={this.goBack} key="backbtn">&lt;- Back</Button>;
+      return <Button block smalltext className={styles.backButton} onClick={this.goBack} key="backbtn">
+        <MaterialIcon className={styles.buttonIcon} icon="arrow_back" /> Back
+      </Button>;
     }
   }
 
@@ -176,9 +178,9 @@ class ActionsPanel extends Component {
           key="showKeybinds"
           className={styles.actionButton}
         >
-          <p><MaterialIcon className={styles.buttonIcon} icon="launch" /></p>
+          <p><MaterialIcon className={styles.buttonIcon} icon="keyboard" /></p>
           Show Keybindings
-          <InfoBox text="Shows the keybinding vieiwer" />
+          <InfoBox text="Shows the keybinding viewer" />
         </Button>
       );
     }
@@ -218,9 +220,7 @@ class ActionsPanel extends Component {
   }
 
   render() {
-    const {
-      popoverVisible, actionLevel, navigationPath, singlewindow,
-    } = this.props;
+    const { popoverVisible, singlewindow } = this.props;
     if (singlewindow) {
       return (this.windowContent);
     }
@@ -285,7 +285,7 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
   }
 
   const allActions = actions.data.shortcuts.filter(action => {
-    if (navPath.length === 1) { 
+    if (navPath.length === 1) {
       return true;
     }
     else {
@@ -299,7 +299,7 @@ const mapSubStateToProps = ({ popoverVisible, luaApi, actions }) => {
       return true;
     }
   });
-  
+
   return {
     actionLevel: actionsForPath,
     popoverVisible,

--- a/src/components/BottomBar/ActionsPanel.scss
+++ b/src/components/BottomBar/ActionsPanel.scss
@@ -1,9 +1,9 @@
 @import "../../styles/all";
 
 .Grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
   &:before,
     &:after {
       display: none;
@@ -17,11 +17,11 @@
 }
 
 .buttonIcon {
-    font-size: 1em;
+  font-size: 1em;
 }
 
 .bottomBarIcon {
-    font-size: 2em;
+  font-size: 2em;
 }
 
 .backButton {
@@ -35,6 +35,7 @@
   margin-bottom: 5px;
   margin: 2px;
   max-height: 50%;
+  overflow-wrap: break-word;
 }
 
 .windowContainer {

--- a/src/components/BottomBar/ActionsPanel.scss
+++ b/src/components/BottomBar/ActionsPanel.scss
@@ -28,8 +28,10 @@
 
 .backButton {
   width: fit-content;
-  padding-left: 8px !important;
-  padding-right: 10px !important;
+  padding-left: 10px !important;
+  padding-bottom: 4px !important;
+  padding-right: 12px !important;
+  font-size: 1em;
 }
 
 .actionButton {

--- a/src/components/BottomBar/ActionsPanel.scss
+++ b/src/components/BottomBar/ActionsPanel.scss
@@ -1,5 +1,7 @@
 @import "../../styles/all";
 
+@import "../common/Popover/Popover.scss";
+
 .Grid {
   display: flex;
   flex-wrap: wrap;
@@ -43,6 +45,11 @@
     min-width: 310px;
     min-height: 100px;
   }
+
+  .navPathTitle {
+    font-size: 1em;
+  }
+
   font-size: 3.4em;
   overflow: scroll;
   overflow-y: auto;
@@ -53,6 +60,12 @@
 
 .folderButton {
   background-color: $ui-background-slider-input;
+}
+
+.navPathTitle {
+  @extend .title;
+  display: inline-block;
+  word-break: break-word;
 }
 
 .actionsPanel {

--- a/src/components/BottomBar/ActionsPanel.scss
+++ b/src/components/BottomBar/ActionsPanel.scss
@@ -27,10 +27,11 @@
 }
 
 .backButton {
+  background-color: $ui-background-slider-input;
   width: fit-content;
   padding-left: 10px !important;
-  padding-bottom: 4px !important;
   padding-right: 12px !important;
+  padding-bottom: 4px;
   font-size: 1em;
 }
 
@@ -68,6 +69,10 @@
   @extend .title;
   display: inline-block;
   word-break: break-word;
+}
+
+.navPathRow {
+  line-height: 1.5em;
 }
 
 .actionsPanel {

--- a/src/components/BottomBar/ActionsPanel.scss
+++ b/src/components/BottomBar/ActionsPanel.scss
@@ -25,7 +25,9 @@
 }
 
 .backButton {
-  width: 25%;
+  width: fit-content;
+  padding-left: 8px !important;
+  padding-right: 10px !important;
 }
 
 .actionButton {

--- a/src/components/SystemMenu/SystemMenu.jsx
+++ b/src/components/SystemMenu/SystemMenu.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { setShowAbout } from '../../api/Actions';
+import { setShowAbout, setPopoverVisibility } from '../../api/Actions';
 import api from '../../api/api';
 import environment from '../../api/Environment';
 import subStateToProps from '../../utils/subStateToProps';
@@ -10,7 +10,7 @@ import Popover from '../common/Popover/Popover';
 import { useContextRefs } from '../GettingStartedTour/GettingStartedContext';
 import styles from './SystemMenu.scss';
 
-function SystemMenu({showAbout, openTutorials, showTutorial, console, nativeGui, quit, saveChange}) {
+function SystemMenu({showAbout, openTutorials, showTutorial, toggleKeybinds, console, nativeGui, quit, saveChange}) {
   const [showMenu, setShowMenu] = React.useState(false);
   const refs = useContextRefs();
   return (
@@ -27,6 +27,10 @@ function SystemMenu({showAbout, openTutorials, showTutorial, console, nativeGui,
             </button>
             <button style={{position : 'relative'}} onClick={() => showTutorial(true)} ref={el => refs.current["Tutorial"] = el}>
               Open Getting Started Tour
+            </button>
+            <hr className={Popover.styles.delimiter} />
+            <button onClick={toggleKeybinds}>
+              <MaterialIcon className={styles.linkIcon} icon="keyboard" />Show keybindings 
             </button>
             {
               environment.developmentMode ?
@@ -101,7 +105,13 @@ const mapSubStateToProps = ({ luaApi }) => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    showAbout: () => dispatch(setShowAbout(true))
+    showAbout: () => dispatch(setShowAbout(true)),
+    toggleKeybinds: () => {
+      dispatch(setPopoverVisibility({
+        popover: 'keybinds',
+        visible: true,
+      }));
+    },
   }
 }
 

--- a/src/components/SystemMenu/SystemMenu.jsx
+++ b/src/components/SystemMenu/SystemMenu.jsx
@@ -10,7 +10,17 @@ import Popover from '../common/Popover/Popover';
 import { useContextRefs } from '../GettingStartedTour/GettingStartedContext';
 import styles from './SystemMenu.scss';
 
-function SystemMenu({showAbout, openTutorials, showTutorial, toggleKeybinds, console, nativeGui, quit, saveChange}) {
+function SystemMenu({
+  console,
+  keybindsIsVisible,
+  nativeGui,
+  openTutorials,
+  saveChange,
+  showAbout,
+  showTutorial,
+  setShowKeybinds,
+  quit
+}) {
   const [showMenu, setShowMenu] = React.useState(false);
   const refs = useContextRefs();
   return (
@@ -29,15 +39,16 @@ function SystemMenu({showAbout, openTutorials, showTutorial, toggleKeybinds, con
               Open Getting Started Tour
             </button>
             <hr className={Popover.styles.delimiter} />
-            <button onClick={toggleKeybinds}>
-              <MaterialIcon className={styles.linkIcon} icon="keyboard" />Show keybindings 
+            <button onClick={() => setShowKeybinds(!keybindsIsVisible)}>
+              <MaterialIcon className={styles.linkIcon} icon="keyboard" />
+              {keybindsIsVisible ? "Hide" : "Show"} keybindings
             </button>
             {
-              environment.developmentMode ?
+              environment.developmentMode &&
                 <div>
                   <hr className={Popover.styles.delimiter} />
                   <div className={styles.devModeNotifier}>GUI running in dev mode</div>
-                </div> : null
+                </div>
             }
             <hr className={Popover.styles.delimiter} />
 
@@ -72,9 +83,10 @@ function SystemMenu({showAbout, openTutorials, showTutorial, toggleKeybinds, con
 
 const mapStateToSubState = (state) => ({
   luaApi: state.luaApi,
+  keybindsIsVisible: state.local.popovers.keybinds.visible,
 });
 
-const mapSubStateToProps = ({ luaApi }) => {
+const mapSubStateToProps = ({ luaApi, keybindsIsVisible }) => {
   if (!luaApi) {
     return {};
   }
@@ -100,16 +112,17 @@ const mapSubStateToProps = ({ luaApi }) => {
     saveChange: async () => {
       luaApi.saveSettingsToProfile();
     },
+    keybindsIsVisible
   };
 };
 
 const mapDispatchToProps = dispatch => {
   return {
     showAbout: () => dispatch(setShowAbout(true)),
-    toggleKeybinds: () => {
+    setShowKeybinds: (visible) => {
       dispatch(setPopoverVisibility({
         popover: 'keybinds',
-        visible: true,
+        visible
       }));
     },
   }


### PR DESCRIPTION
A variety of small updates to the actions panel, including: 

- Fix axtions not showing if Gui path does not start with /, or if the Gui paht is empty
- Truncate and linebreak long nav paths and action names
- Move show keybindings to hamburger menu (and remove from acitons panel)
- Change styling of back button

Remaining things to do (will be made new issues): 
- Figure out where to place keybindings button in actions panel, if we still want it there. Once testing it I found it quite natural that it was available only in the hamburger menu
- Click folder in nav path to go to that level
- Truncation of nav path is very hardcoded and always only shows first and last part of path. Would be better to just truncate to the max length and show all folders closest to the current folder, Especially if the point above is implemented