### PR TITLE
Fix sky browser space craft pointing

### DIFF
--- a/src/components/BottomBar/SkyBrowser/SkyBrowserSettings.jsx
+++ b/src/components/BottomBar/SkyBrowser/SkyBrowserSettings.jsx
@@ -306,7 +306,7 @@ function SkyBrowserSettings({
         ))}
       </Row>
       <Property uri={`Scene.${browser.targetId}.Renderable.ApplyRoll`} />
-      <Property uri={`ScreenSpace.${selectedBrowserId}.PointSpaceCraft`} />
+      <Property uri={`ScreenSpace.${selectedBrowserId}.PointSpacecraft`} />
       {displayDisplaySection}
       <ToggleContent
         title={"General Settings"}

--- a/src/components/BottomBar/SkyBrowser/SkyBrowserSettings.jsx
+++ b/src/components/BottomBar/SkyBrowser/SkyBrowserSettings.jsx
@@ -305,7 +305,8 @@ function SkyBrowserSettings({
           />
         ))}
       </Row>
-      <Property uri={`Scene.${browser.targetId}.Renderable.ApplyRoll`}/>
+      <Property uri={`Scene.${browser.targetId}.Renderable.ApplyRoll`} />
+      <Property uri={`ScreenSpace.${selectedBrowserId}.PointSpaceCraft`} />
       {displayDisplaySection}
       <ToggleContent
         title={"General Settings"}

--- a/src/components/BottomBar/SkyBrowser/SkyBrowserTabs.jsx
+++ b/src/components/BottomBar/SkyBrowser/SkyBrowserTabs.jsx
@@ -20,7 +20,6 @@ const ButtonIds = {
   RemoveImages: "RemoveImages",
   ZoomIn: "ZoomIn",
   ZoomOut: "ZoomOut",
-  PointSpaceCraft: "PointSpaceCraft",
   Settings: "Settings"
 }
 
@@ -190,16 +189,6 @@ function SkyBrowserTabs({
         luaApi.skybrowser.setVerticalFov(browserId, Number(newFov));
       },
     };
-    const pointSpaceCraftButton = {
-      id: ButtonIds.PointSpaceCraft,
-      selected: false,
-      icon: 'eos-icons:satellite-alt',
-      iconify: true,
-      text: 'Point spacecraft',
-      function: function(browserId) {
-        luaApi.skybrowser.pointSpaceCraft(browserId);
-      },
-    };
     const showSettingsButton = {
       id: ButtonIds.Settings,
       selected: showSettings,
@@ -210,7 +199,7 @@ function SkyBrowserTabs({
       },
     };
 
-    const buttonsData = [lookButton, moveButton, scrollInButton, scrollOutButton, pointSpaceCraftButton, trashButton, showSettingsButton];
+    const buttonsData = [lookButton, moveButton, scrollInButton, scrollOutButton, trashButton, showSettingsButton];
 
     const buttons = buttonsData.map((button) => (
       <Button


### PR DESCRIPTION
This PR makes the pointing of the space craft a property you can set in the settings in the GUI. If checked, the spacecraft will be pointed when an image is selected. To be used with  https://github.com/OpenSpace/OpenSpace/pull/2456