### PR TITLE
Allow entering value outside min max range for numeric input 

### DIFF
--- a/src/components/BottomBar/SimulationIncrement.jsx
+++ b/src/components/BottomBar/SimulationIncrement.jsx
@@ -201,6 +201,7 @@ function SimulationIncrement({hasNextDeltaTimeStep, hasPrevDeltaTimeStep, nextDe
           value={-adjustedDelta}
           reverse
           noValue={adjustedDelta >= 0}
+          showOutsideRangeHint={false}
         />
         <NumericInput
           {...Limits[stepSize]}
@@ -209,6 +210,7 @@ function SimulationIncrement({hasNextDeltaTimeStep, hasPrevDeltaTimeStep, nextDe
           placeholder={`${stepSize} / second`}
           value={adjustedDelta}
           noValue={adjustedDelta < 0}
+          showOutsideRangeHint={false}
         />
       </Row>
       <div style={{ height: '10px' }} />

--- a/src/components/Sidebar/Properties/Property.scss
+++ b/src/components/Sidebar/Properties/Property.scss
@@ -5,7 +5,7 @@
   margin-bottom: 3px;
 
   &:hover label {
-    color: $yellow;
+    color: $text-color-focus;
   }
 
   label {

--- a/src/components/Sidebar/Properties/Property.scss
+++ b/src/components/Sidebar/Properties/Property.scss
@@ -5,7 +5,7 @@
   margin-bottom: 3px;
 
   &:hover label {
-    color: $green;
+    color: $yellow;
   }
 
   label {

--- a/src/components/common/Input/Input/Input.jsx
+++ b/src/components/common/Input/Input/Input.jsx
@@ -36,7 +36,7 @@ class Input extends Component {
    * @param event InputEvent
    */
   onChange(event) {
-    const { value } = event.target;
+    let { value } = event.currentTarget;
 
     // update state so that input is re-rendered with new content
     this.setState({ value });

--- a/src/components/common/Input/Input/Input.jsx
+++ b/src/components/common/Input/Input/Input.jsx
@@ -58,7 +58,7 @@ class Input extends Component {
     //this solution is so bad it only lets you put . at the end of a value.
     //but I feel its still better then nothing happening.
     if ( (window.navigator.platform == "Win32") && ((event.keyCode == 46)) ) {
-      var charString = String.fromCharCode(event.keyCode);
+      let charString = String.fromCharCode(event.keyCode);
       if (event.currentTarget.type == "number") {
         charString += "0";
       }

--- a/src/components/common/Input/Input/Input.scss
+++ b/src/components/common/Input/Input/Input.scss
@@ -51,7 +51,7 @@ $padding-loading: $padding-top $padding-horizontal $padding-bottom-loading;
   outline: 0;
 
   ~ .label {
-    color: $yellow;
+    color: $text-color-focus;
   }
 }
 
@@ -70,11 +70,11 @@ $padding-loading: $padding-top $padding-horizontal $padding-bottom-loading;
 
 .buttonsContainer {
   pointer-events: none;
-  display: flex; 
+  display: flex;
   justify-content: flex-end;
-  position: absolute; 
-  top: 0; 
-  width: 100%; 
+  position: absolute;
+  top: 0;
+  width: 100%;
   height: 100%;
 }
 

--- a/src/components/common/Input/Input/Input.scss
+++ b/src/components/common/Input/Input/Input.scss
@@ -51,7 +51,7 @@ $padding-loading: $padding-top $padding-horizontal $padding-bottom-loading;
   outline: 0;
 
   ~ .label {
-    color: $green;
+    color: $yellow;
   }
 }
 
@@ -132,7 +132,7 @@ $padding-loading: $padding-top $padding-horizontal $padding-bottom-loading;
     border-bottom: $loading-border-width solid $blue;
   }
   50% {
-    border-bottom: $loading-border-width solid $green;
+    border-bottom: $loading-border-width solid $yellow;
   }
   100% {
     border-bottom: $loading-border-width solid $blue;

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.jsx
@@ -299,7 +299,6 @@ class MinMaxRangeInput extends Component {
   }
 
   textTooltipPosition() {
-    console.log(this.wrapperRef);
     if (!this.wrapperRef) return { top: '0px', left: '0px' };
     const { top, right } = this.wrapperRef.getBoundingClientRect();
     return { top: `${top}px`, left: `${right}px` };

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
@@ -120,3 +120,11 @@
       transparent var(--bg-stop)
     );
 }
+
+.outsideMinMaxRange {
+  color: $yellow !important;
+}
+
+.invalidValue {
+  color: $ui-danger !important;
+}

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
@@ -54,7 +54,7 @@
 // state changes
 .inputGroup {
   .range:focus + .rangeLabel {
-    color: $yellow;
+    color: $text-color-focus;
   }
 
   &:hover {

--- a/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
+++ b/src/components/common/Input/MinMaxRangeInput/MinMaxRangeInput.scss
@@ -54,7 +54,7 @@
 // state changes
 .inputGroup {
   .range:focus + .rangeLabel {
-    color: $green;
+    color: $yellow;
   }
 
   &:hover {

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -171,22 +171,26 @@ class NumericInput extends Component {
 
   render() {
     const { value, id, isValueOutsideRange, hoverHint } = this.state;
-    const { decimals } = this.props;
+    const { decimals, showOutsideRangeHint } = this.props;
 
     if (this.showTextInput) {
-      let excludeProps = 'reverse onValueChanged inputOnly noHoverHint noTooltip noValue exponent';
+      let excludeProps = 'reverse onValueChanged inputOnly noHoverHint noTooltip noValue exponent showOutsideRangeHint';
+      let inputClassName = '';
 
       // If we are already outside the range, sclude the min max properties to the HTML
       // input. But while inside the range we want them to affect what value is possible
       // to set using .e.g the arrow keys
       if (isValueOutsideRange) {
         excludeProps += ' min max';
+        if (showOutsideRangeHint) {
+          inputClassName += styles.outsideMinMaxRange;
+        }
       }
 
       return (
         <Input
           {...excludeKeys(this.props, excludeProps)}
-          className={isValueOutsideRange ? styles.outsideMinMaxRange : ''}
+          className={inputClassName}
           type="number"
           value={value}
           onBlur={this.onTextBlurOrEnter}
@@ -199,7 +203,7 @@ class NumericInput extends Component {
 
     const { placeholder, className, label, wide, reverse, noValue } = this.props;
     const doNotInclude = 'wide reverse onValueChanged value className type min max step exponent ' +
-                         'inputOnly label noHoverHint noTooltip noValue';
+                         'inputOnly label noHoverHint noTooltip noValue showOutsideRangeHint';
     const inheritedProps = excludeKeys(this.props, doNotInclude);
     const hoverHintOffset = reverse ? 1 - hoverHint : hoverHint;
 
@@ -262,6 +266,7 @@ NumericInput.propTypes = {
   noValue: PropTypes.bool,
   onValueChanged: PropTypes.func,
   placeholder: PropTypes.string.isRequired,
+  showOutsideRangeHint: PropTypes.bool,
   step: PropTypes.number,
   value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   wide: PropTypes.bool,
@@ -281,6 +286,7 @@ NumericInput.defaultProps = {
   noTooltip: false,
   noValue: false,
   onValueChanged: () => {},
+  showOutsideRangeHint: true,
   step: 1,
   value: 0,
   wide: true,

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -186,7 +186,6 @@ class NumericInput extends Component {
   }
 
   textTooltipPosition() {
-    console.log(this.wrapperRef);
     if (!this.wrapperRef) return { top: '0px', left: '0px' };
     const { top, right } = this.wrapperRef.getBoundingClientRect();
     return { top: `${top}px`, left: `${right}px` };

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -201,9 +201,9 @@ class NumericInput extends Component {
       let tootipContent = "";
       let showTooltip = false;
 
-      // If we are already outside the range, sclude the min max properties to the HTML
+      // If we are already outside the range, exclude the min max properties to the HTML
       // input. But while inside the range we want them to affect what value is possible
-      // to set using .e.g the arrow keys
+      // to set using e.g. the arrow keys
       if (isValueOutsideRange) {
         excludeProps += ' min max';
         if (showOutsideRangeHint) {
@@ -217,7 +217,6 @@ class NumericInput extends Component {
 
       if (showOutsideRangeHint && enteredInvalidValue) {
         inputClassName += styles.invalidValue;
-        // TODO: update tooltip content
         showTooltip = true;
         tootipContent = <p>{ "Value is not a number"}</p>;
       }

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -198,8 +198,6 @@ class NumericInput extends Component {
           showTooltip = true;
           tootipContent = <>
             <p>{`Value is outside the valid range: `}<b>{`[${min}, ${max}].`}</b></p>
-            <br/>
-            <p>{"May lead to unexpected/undesired behavior"}</p>
           </>
         }
       }
@@ -208,7 +206,7 @@ class NumericInput extends Component {
         inputClassName += styles.invalidValue;
         // TODO: update tooltip content
         showTooltip = true;
-        tootipContent = <p>{ "Value is not a number! Input will be ignored"}</p>;
+        tootipContent = <p>{ "Value is not a number"}</p>;
       }
 
       return (

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -171,7 +171,7 @@ class NumericInput extends Component {
 
   render() {
     const { value, id, isValueOutsideRange, hoverHint } = this.state;
-    const { decimals, showOutsideRangeHint } = this.props;
+    const { decimals, min, max, showOutsideRangeHint } = this.props;
 
     if (this.showTextInput) {
       let excludeProps = 'reverse onValueChanged inputOnly noHoverHint noTooltip noValue exponent showOutsideRangeHint';
@@ -188,16 +188,24 @@ class NumericInput extends Component {
       }
 
       return (
-        <Input
-          {...excludeKeys(this.props, excludeProps)}
-          className={inputClassName}
-          type="number"
-          value={value}
-          onBlur={this.onTextBlurOrEnter}
-          onChange={this.onTextInputChange}
-          onEnter={this.onTextBlurOrEnter}
-          autoFocus
-        />
+        <div className={`${styles.inputGroup}`}>
+          {showOutsideRangeHint && isValueOutsideRange &&
+            <Tooltip style={{ left: `50%` }} placement={'top'}>
+              { `Value is outside the property's min/max range: \n [${min}, ${max}].` }
+              { "Might lead to undesired behavior" }
+            </Tooltip>
+          }
+          <Input
+            {...excludeKeys(this.props, excludeProps)}
+            className={inputClassName}
+            type="number"
+            value={value}
+            onBlur={this.onTextBlurOrEnter}
+            onChange={this.onTextInputChange}
+            onEnter={this.onTextBlurOrEnter}
+            autoFocus
+          />
+        </div>
       );
     }
 

--- a/src/components/common/Input/NumericInput/NumericInput.jsx
+++ b/src/components/common/Input/NumericInput/NumericInput.jsx
@@ -22,6 +22,9 @@ class NumericInput extends Component {
       enteredInvalidValue: false
     };
 
+    this.setRef = this.setRef.bind(this);
+    this.textTooltipPosition = this.textTooltipPosition.bind(this);
+
     this.roundValueToStepSize = this.roundValueToStepSize.bind(this);
 
     this.updateSliderScale = this.updateSliderScale.bind(this);
@@ -55,6 +58,10 @@ class NumericInput extends Component {
     if (scaleNeedsUpdate) {
       this.scale = this.updateSliderScale();
     }
+  }
+
+  setRef(what) {
+    return (element) => { this[what] = element; };
   }
 
   roundValueToStepSize(value) {
@@ -178,12 +185,19 @@ class NumericInput extends Component {
     this.setState({ showTextInput: false, hoverHint: null});
   }
 
+  textTooltipPosition() {
+    console.log(this.wrapperRef);
+    if (!this.wrapperRef) return { top: '0px', left: '0px' };
+    const { top, right } = this.wrapperRef.getBoundingClientRect();
+    return { top: `${top}px`, left: `${right}px` };
+  }
+
   render() {
     const { value, id, isValueOutsideRange, enteredInvalidValue, hoverHint } = this.state;
     const { decimals, min, max, showOutsideRangeHint } = this.props;
 
     if (this.showTextInput) {
-      let excludeProps = 'reverse onValueChanged inputOnly noHoverHint noTooltip noValue exponent showOutsideRangeHint';
+      let excludeProps = 'wide reverse onValueChanged inputOnly noHoverHint noTooltip noValue exponent showOutsideRangeHint';
       let inputClassName = '';
       let tootipContent = "";
       let showTooltip = false;
@@ -210,12 +224,7 @@ class NumericInput extends Component {
       }
 
       return (
-        <div className={`${styles.inputGroup}`}>
-          {showTooltip &&
-            <Tooltip className={inputClassName} style={{ left: `50%` }} placement={'top'}>
-              {tootipContent}
-            </Tooltip>
-          }
+        <div className={`${styles.inputGroup} ${wide ? styles.wide : ''}` } ref={this.setRef('wrapperRef')}>
           <Input
             {...excludeKeys(this.props, excludeProps)}
             className={inputClassName}
@@ -226,6 +235,11 @@ class NumericInput extends Component {
             onEnter={this.onTextBlurOrEnter}
             autoFocus
           />
+          {showTooltip &&
+            <Tooltip className={inputClassName} fixed style={{...this.textTooltipPosition()}} placement={'right'}>
+              {tootipContent}
+            </Tooltip>
+          }
         </div>
       );
     }
@@ -244,6 +258,7 @@ class NumericInput extends Component {
     return (
       <div
         className={`${styles.inputGroup} ${wide ? styles.wide : ''} ${reverse ? styles.reverse : ''}`}
+        ref={this.setRef('wrapperRef')}
         onDoubleClick={this.enableTextInput}
         onContextMenu={this.enableTextInput}
       >

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -6,6 +6,7 @@
   position: relative;
   box-sizing: border-box;
   height: $input-total-height;
+  flex: 1 1 0px;
 }
 
 // the descriptive label
@@ -61,7 +62,7 @@
 // state changes
 .inputGroup {
   .range:focus + .rangeLabel {
-    color: $yellow;
+    color: $text-color-focus;
   }
 
   &:hover {
@@ -120,7 +121,7 @@
 }
 
 .outsideMinMaxRange {
-  color: $ui-warning !important;
+  color: $yellow !important;
 }
 
 .invalidValue {

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -120,5 +120,5 @@
 }
 
 .outsideMinMaxRange {
-  color: red !important;
+  color: $ui-warning !important;
 }

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -118,3 +118,7 @@
   height: 100%;
   min-width: 2px;
 }
+
+.outsideMinMaxRange {
+  color: red !important;
+}

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -61,7 +61,7 @@
 // state changes
 .inputGroup {
   .range:focus + .rangeLabel {
-    color: $green;
+    color: $yellow;
   }
 
   &:hover {

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -32,6 +32,8 @@
   bottom: $padding-bottom;
   left: $padding-horizontal;
   pointer-events: none;
+  width: calc(100% - $padding-horizontal);
+  overflow: hidden;
 }
 
 .reverse .value {

--- a/src/components/common/Input/NumericInput/NumericInput.scss
+++ b/src/components/common/Input/NumericInput/NumericInput.scss
@@ -122,3 +122,7 @@
 .outsideMinMaxRange {
   color: $ui-warning !important;
 }
+
+.invalidValue {
+  color: $ui-danger !important;
+}

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,6 +1,6 @@
 // color definitions
 $dark-grey: #181818;
-$green: #D9DA6D;
+$yellow: #D9DA6D;
 $blue: #3DBDEE;
 $red: #FF4136;
 $orange: #FF851B;
@@ -18,7 +18,7 @@ $ui-warning: $orange;
 
 $ui-divider: darken($ui-background, 1%);
 
-$ui-highlight-primary: $green;
+$ui-highlight-primary: $yellow;
 $ui-highlight-secondary: $blue;
 
 $text-color-focus: white;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,6 +1,6 @@
 // color definitions
 $dark-grey: #181818;
-$yellow: #D9DA6D;
+$yellow: #ebd972;
 $blue: #3DBDEE;
 $red: #FF4136;
 $orange: #FF851B;
@@ -15,11 +15,9 @@ $ui-background-slider-input: rgba(white, 0.1);
 
 $ui-danger: $red;
 $ui-warning: $orange;
+$ui-highlight-secondary: $blue;
 
 $ui-divider: darken($ui-background, 1%);
-
-$ui-highlight-primary: $yellow;
-$ui-highlight-secondary: $blue;
 
 $text-color-focus: white;
 $text-color-blur: darken($text-color-focus, 40%);

--- a/src/views/About/About.scss
+++ b/src/views/About/About.scss
@@ -36,6 +36,6 @@
 }
 
 .notification {
-  color: $green;
+  color: $yellow;
 }
 


### PR DESCRIPTION
https://github.com/OpenSpace/OpenSpace/issues/2449

Shows invalid value in red and outside of min/max range in yellow. For both NumericInput and MinMaxRangeInput

Behavior for minMaxRange can be considered a little weird, as there is only one tooltip for two inputs. But, I did not want to overcomplicate that code. Hopefully, it's good enough. Example of what I mean shown in video below. At least both of the values share the same min and max range

https://user-images.githubusercontent.com/8808894/229716043-c8aba698-6916-4a5d-85d5-998787d8de8f.mov

