### PR TITLE
Avoid hiding property owners with only an enabled property (closes OpenSpace/OpenSpace#2528)

### DIFF
--- a/src/components/NodePropertiesPanel/NodePropertiesPanel.jsx
+++ b/src/components/NodePropertiesPanel/NodePropertiesPanel.jsx
@@ -53,7 +53,7 @@ class NodePropertiesPanel extends Component {
             return <Property key={prop} uri={propUri} />;
           }
         })
-      } 
+      }
       else {
         return <PropertyOwner autoExpand={true}
                               key={0}
@@ -76,16 +76,16 @@ class NodePropertiesPanel extends Component {
               return this.propertyOwnerForUri(activeTab, uri);
             }
           }
-      }      
+      }
     } else {
       return;
     }
   }
 
   buttonForTab(activeTab, index, title) {
-    return <Button block 
-        largetext={activeTab == index} smalltext={activeTab != index} 
-        key={index} 
+    return <Button block
+        largetext={activeTab == index} smalltext={activeTab != index}
+        key={index}
         onClick={() => this.props.setPopoverActiveTabAction(index)}
       >
         {title}
@@ -139,14 +139,14 @@ class NodePropertiesPanel extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  let aim = state.propertyTree.properties[NavigationAnchorKey] ? 
-    state.propertyTree.properties[NavigationAnchorKey].value : 
+  let aim = state.propertyTree.properties[NavigationAnchorKey] ?
+    state.propertyTree.properties[NavigationAnchorKey].value :
     undefined;
 
   var nodeURI = ownProps.isFocusNodePanel ? ScenePrefixKey + aim : ownProps.uri;
 
-  let myPopover = ownProps.isFocusNodePanel ? 
-    state.local.popovers.focusNodePropertiesPanel : 
+  let myPopover = ownProps.isFocusNodePanel ?
+    state.local.popovers.focusNodePropertiesPanel :
     state.local.popovers.activeNodePropertyPanels[ownProps.uri];
 
   var popoverVisible = myPopover ? myPopover.visible : false;
@@ -156,7 +156,7 @@ const mapStateToProps = (state, ownProps) => {
   const node = state.propertyTree.propertyOwners[nodeURI] ? state.propertyTree.propertyOwners[nodeURI] : {};
   const nodeName = node.name;
 
-  const renderableProps = state.propertyTree.propertyOwners[nodeURI+".Renderable"] ? 
+  const renderableProps = state.propertyTree.propertyOwners[nodeURI+".Renderable"] ?
     state.propertyTree.propertyOwners[nodeURI+".Renderable"].properties :
     null;
 

--- a/src/components/Sidebar/Group.jsx
+++ b/src/components/Sidebar/Group.jsx
@@ -4,9 +4,9 @@ import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { setPropertyTreeExpansion } from '../../api/Actions';
 import { sortGroups } from '../../api/keys';
 import ToggleContent from '../common/ToggleContent/ToggleContent';
-import PropertyOwner, { 
-  displayName as propertyOwnerName, 
-  nodeExpansionIdentifier as propertyOwnerNodeExpansionIdentifier 
+import PropertyOwner, {
+  displayName as propertyOwnerName,
+  nodeExpansionIdentifier as propertyOwnerNodeExpansionIdentifier
 } from './Properties/PropertyOwner';
 
 function isEnabled(properties, uri) {
@@ -16,7 +16,7 @@ function isEnabled(properties, uri) {
 function enabledPropertyOwners(state, path) {
   const data = state.groups[path] || {};
   const propertyOwners = data.propertyOwners || [];
-  
+
   // Filter PropertyOwners
   return propertyOwners.filter((propertyOwner) =>
     isEnabled(state.propertyTree.properties, propertyOwner)
@@ -29,7 +29,7 @@ function shouldShowGroup(state, path) {
   // If there are any enabled property owners in the result,
   // show the groups
   if (subGroups.length === 0) {
-    return enabledPropertyOwners(state, path).length !== 0; 
+    return enabledPropertyOwners(state, path).length !== 0;
   }
   const initialValue = false;
   const result = subGroups.reduce(
@@ -43,11 +43,7 @@ function shouldShowGroup(state, path) {
 
 function displayName(path) {
   const splitPath = path.split('/');
-  if (splitPath.length > 1) {
-    return splitPath[splitPath.length - 1];
-  } else {
-    return 'Untitled';
-  }
+  return (splitPath.length > 1) ? splitPath[splitPath.length - 1] : 'Untitled';
 }
 
 /**
@@ -79,9 +75,9 @@ function Group({ path, expansionIdentifier, autoExpand, showOnlyEnabled }) {
     }
     // Extract propertyOwners
     return owners.map(owner => ({
-        type: 'propertyOwner',
-        payload: owner,
-        name: propertyOwnerName(state.propertyTree.propertyOwners, state.propertyTree.properties, owner)
+      type: 'propertyOwner',
+      payload: owner,
+      name: propertyOwnerName(state.propertyTree.propertyOwners, state.propertyTree.properties, owner)
     }));
   }, shallowEqual);
 
@@ -90,16 +86,14 @@ function Group({ path, expansionIdentifier, autoExpand, showOnlyEnabled }) {
     const subGroups = data.subgroups || [];
 
     // Extract groups
-    let groups = subGroups.map(subGroup => ({
+    const groups = subGroups.map(subGroup => ({
       type: 'group',
       payload: subGroup,
       name: displayName(subGroup)
     }));
     // See if the groups contain any PropertyOwners
     if (showOnlyEnabled) {
-      return groups.filter((group) => {
-        return shouldShowGroup(state, group.payload);
-      });
+      return groups.filter((group) => shouldShowGroup(state, group.payload));
     }
     return groups;
   })
@@ -125,48 +119,46 @@ function Group({ path, expansionIdentifier, autoExpand, showOnlyEnabled }) {
 
   if (sortOrdering && sortOrdering.value) {
       sortedEntries.sort((a,b) => {
-        if (sortOrdering.value.indexOf(a.name) < sortOrdering.value.indexOf(b.name)) {
-          return -1;
-        } else {
-          return 1;
-        }
+        return sortOrdering.value.indexOf(a.name) < sortOrdering.value.indexOf(b.name) ?
+          -1 : 1;
       });
   }
 
-  return hasEntries && <ToggleContent
-    title={displayName(path)}
-    expanded={isExpanded}
-    setExpanded={setExpanded}
-  >
-    {
-      sortedEntries.map(entry => {
-        const autoExpand = entries.length === 1;
-        switch (entry.type) {
-          case 'group': {
-            const childNodeIdentifier = expansionIdentifier + '/' +
-              nodeExpansionIdentifier(entry.payload);
+  return hasEntries &&
+    <ToggleContent
+      title={displayName(path)}
+      expanded={isExpanded}
+      setExpanded={setExpanded}
+    >
+      {
+        sortedEntries.map(entry => {
+          const autoExpand = entries.length === 1;
+          switch (entry.type) {
+            case 'group': {
+              const childNodeIdentifier = expansionIdentifier + '/' +
+                nodeExpansionIdentifier(entry.payload);
 
-            return <Group autoExpand={autoExpand}
-                          key={entry.payload}
-                          path={entry.payload}
-                          expansionIdentifier={childNodeIdentifier}
-                          showOnlyEnabled={showOnlyEnabled} />
+              return <Group autoExpand={autoExpand}
+                            key={entry.payload}
+                            path={entry.payload}
+                            expansionIdentifier={childNodeIdentifier}
+                            showOnlyEnabled={showOnlyEnabled} />
             }
-          case 'propertyOwner': {
-            const childNodeIdentifier = expansionIdentifier + '/' +
-              propertyOwnerNodeExpansionIdentifier(entry.payload);
+            case 'propertyOwner': {
+              const childNodeIdentifier = expansionIdentifier + '/' +
+                propertyOwnerNodeExpansionIdentifier(entry.payload);
 
-            return <PropertyOwner autoExpand={autoExpand}
-                                  key={entry.payload}
-                                  uri={entry.payload}
-                                  expansionIdentifier={childNodeIdentifier} />
+              return <PropertyOwner autoExpand={autoExpand}
+                                    key={entry.payload}
+                                    uri={entry.payload}
+                                    expansionIdentifier={childNodeIdentifier} />
             }
-          default:
-            return null;
-        }
-      })
-    }
-  </ToggleContent>
+            default:
+              return null;
+          }
+        })
+      }
+    </ToggleContent>
 }
 
 Group.propTypes = {

--- a/src/components/Sidebar/Properties/PropertyOwner.jsx
+++ b/src/components/Sidebar/Properties/PropertyOwner.jsx
@@ -16,6 +16,7 @@ import {
   getLayerGroupFromUri,
   getSceneGraphNodeFromUri,
   isDeadEnd,
+  isEnabledProperty,
   isGlobeBrowsingLayer,
   isPropertyOwnerHidden,
   isPropertyVisible,
@@ -267,7 +268,9 @@ const mapSubStateToProps = (
   subowners.forEach((uri) => {
     subownerNames[uri] = displayName(propertyOwners, properties, uri);
   });
-  subProperties = subProperties.filter(uri => isPropertyVisible(properties, uri));
+
+  // Find all the subproperties of this owner (do not include the enabled property)
+  subProperties = subProperties.filter(uri => isPropertyVisible(properties, uri) && !isEnabledProperty(uri));
 
   const shouldSort = shouldSortAlphabetically(uri);
 

--- a/src/components/Sidebar/ScenePane.jsx
+++ b/src/components/Sidebar/ScenePane.jsx
@@ -28,8 +28,8 @@ function ScenePane({ closeCallback }) {
       }).map(path =>
         path.slice(1) // Remove leading slash
       ).reduce((obj, key) => ({ // Convert back to object
-          ...obj,
-          [key]: true
+        ...obj,
+        [key]: true
       }), {}
     );
 
@@ -52,11 +52,12 @@ function ScenePane({ closeCallback }) {
     // Add back the leading slash
     sortedGroups = sortedGroups.map(path => '/' + path);
     return sortedGroups;
-  }, shallowEqual);  
+  }, shallowEqual);
 
   const propertyOwners = useSelector((state) => state.propertyTree.propertyOwners, shallowEqual);
   const properties = useSelector((state) => state.propertyTree.properties, shallowEqual);
   const propertyOwnersScene = propertyOwners.Scene?.subowners ?? [];
+
   function matcher(test, search) {
     const node = propertyOwners[test.uri] || {};
     const guiHidden = isPropertyOwnerHidden(properties, test.uri);
@@ -74,11 +75,11 @@ function ScenePane({ closeCallback }) {
     uri: uri,
     expansionIdentifier: 'scene-search/' + uri
   }));
-  
+
   const favorites = groups.map(item => ({
     key: item,
     path: item,
-    expansionIdentifier: 'scene/' + item 
+    expansionIdentifier: 'scene/' + item
   }));
 
   const settingsButton = (
@@ -105,22 +106,20 @@ function ScenePane({ closeCallback }) {
 
   return (
     <Pane title="Scene" closeCallback={closeCallback} headerButton={settingsButton}>
-      {(entries.length === 0) && (
+      {(entries.length === 0) &&
         <LoadingBlocks className={Pane.styles.loading} />
-      )}
-      {entries.length > 0 && (
-        <>
-          <FilterList matcher={showOnlyEnabled ? onlyEnabledMatcher : matcher}>
-            <FilterListFavorites>
-              <ContextSection expansionIdentifier="context" />
-              {favorites.map(favorite => <Group {...favorite} showOnlyEnabled={showOnlyEnabled} />)}
-            </FilterListFavorites>
-            <FilterListData>
-              {entries.map(entry => <PropertyOwner {...entry} />)}
-            </FilterListData>
-          </FilterList> 
-        </>
-      )}
+      }
+      {entries.length > 0 &&
+        <FilterList matcher={showOnlyEnabled ? onlyEnabledMatcher : matcher}>
+          <FilterListFavorites>
+            <ContextSection expansionIdentifier="context" />
+            {favorites.map(favorite => <Group {...favorite} showOnlyEnabled={showOnlyEnabled} />)}
+          </FilterListFavorites>
+          <FilterListData>
+            {entries.map(entry => <PropertyOwner {...entry} />)}
+          </FilterListData>
+        </FilterList>
+      }
     </Pane>
   );
 }

--- a/src/components/common/ToggleContent/ToggleContent.jsx
+++ b/src/components/common/ToggleContent/ToggleContent.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import styles from './ToggleContent.scss';
 import ToggleHeader from './ToggleHeader';
 
@@ -18,26 +18,27 @@ function ToggleContent({setExpanded, children, header, title, expanded, showEnab
     setHovered(false);
   }
 
-  if(!(children.length !== 0 && ((children[0].length != 0) || (children[1].length != 0)))) {
+  if (!(children.length !== 0 && ((children[0].length != 0) || (children[1].length != 0)))) {
     return null;
   }
   else {
     return (
-    <div className={styles.toggleContent}
-          onMouseEnter={mouseEntered}
-          onMouseLeave={mouseLeft}>
-      { header ? header : 
-        <ToggleHeader
-          title={title}
-          onClick={toggleExpanded}
-          showEnabled={showEnabled}
-          expanded={expanded}
-        />
-      }
-      <div className={styles.content}>
-        { expanded && children }
+      <div className={styles.toggleContent}
+            onMouseEnter={mouseEntered}
+            onMouseLeave={mouseLeft}>
+        { header ? header :
+          <ToggleHeader
+            title={title}
+            onClick={toggleExpanded}
+            showEnabled={showEnabled}
+            expanded={expanded}
+          />
+        }
+        <div className={styles.content}>
+          { expanded && children }
+        </div>
       </div>
-    </div>);
+    );
   }
 }
 

--- a/src/utils/propertyTreeHelpers.js
+++ b/src/utils/propertyTreeHelpers.js
@@ -112,16 +112,12 @@ export function removeLastWordFromUri(uri) {
 // Returns whether a property should be visible in the gui
 export function isPropertyVisible(properties, uri) {
   const property = properties[uri];
-  const visibility = properties['OpenSpaceEngine.PropertyVisibility'];
   if (!property?.description?.MetaData?.Visibility) {
     return false;
   }
-  // Don't show the property "Enabled"
-  const splitUri = uri.split('.');
-  if (splitUri.length > 1 && splitUri[splitUri.length - 1] === 'Enabled') {
-      return false;
-  }
 
+  // Only show properties matching the current visibility setting
+  const visibility = properties['OpenSpaceEngine.PropertyVisibility'];
   let propertyVisibility = "";
   switch (property.description.MetaData.Visibility) {
     case 'Hidden':
@@ -168,6 +164,7 @@ export function isDeadEnd(propertyOwners, properties, uri) {
   const visibleProperties = subproperties.filter(
     childUri => isPropertyVisible(properties, childUri)
   );
+
   if (visibleProperties.length > 0) {
     return false;
   }
@@ -224,4 +221,9 @@ export function getSceneGraphNodeFromUri(uri) {
     return undefined;
   }
   return splitUri[1];
+}
+
+export function isEnabledProperty(uri) {
+  const splitUri = uri.split('.');
+  return (splitUri.length > 1 && splitUri[splitUri.length - 1] === 'Enabled');
 }


### PR DESCRIPTION
Ended up keeping the chevron icon for empty property owners, as any alternative looked weird or was very confusing. 