### PR TITLE
Add wait for globe rendering checkbox (commit from PR #144)

### DIFF
--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -38,6 +38,7 @@ function SessionRec() {
   const [outputFramerate, setOutputFramerate] = React.useState(60);
   const [loopPlayback, setLoopPlayback] = React.useState(false);
   const [showPopover, setShowPopover] = React.useState(false);
+  const [waitForGlobeRendering, setWaitForGlobeRendering] = React.useState(false);
 
   const luaApi = useSelector((state) => state.luaApi);
 
@@ -119,7 +120,7 @@ function SessionRec() {
       luaApi.sessionRecording.enableTakeScreenShotDuringPlayback(parseInt(outputFramerate, 10));
     }
     if (forceTime) {
-      luaApi.sessionRecording.startPlayback(filenamePlayback, loopPlayback);
+      luaApi.sessionRecording.startPlayback(filenamePlayback, loopPlayback, waitForGlobeRendering);
     } else {
       luaApi.sessionRecording.startPlaybackRecordedTime(filenamePlayback, loopPlayback);
     }
@@ -312,8 +313,8 @@ function SessionRec() {
               <p>Output frames</p>
               <InfoBox
                 className={styles.infoBox}
-                text={`If checked, the specified number of frames will be recorded as 
-                screenshots and saved to disk. Per default, they are saved in the  
+                text={`If checked, the specified number of frames will be recorded as
+                screenshots and saved to disk. Per default, they are saved in the
                 user/screenshots folder. This feature can not be used together with
                 'loop playback'`}
               />
@@ -329,6 +330,21 @@ function SessionRec() {
               />
             )}
           </Row>
+          {shouldOutputFrames && (
+            <Checkbox
+              checked={waitForGlobeRendering}
+              setChecked={setWaitForGlobeRendering}
+              name="waitForGlobeRendering"
+            >
+              <p>Wait for Globe Loading</p>
+              <InfoBox
+                className={styles.infoBox}
+                text={`If this is checked, the session recording will pause the rendering
+                    while images on Globes are loading. While this usually works well, it might
+                    cause the application to freeze if a data provider is unavailable`}
+              />
+            </Checkbox>
+          )}
           <Row>
             <Select
               menuPlacement="top"


### PR DESCRIPTION
But applied on the updated SessionRecording code, that hade been rewritten quite a bit as part of the linting updates

Replaces PR #144 (I just copied over the code from @ylvaselling's commit)



Ylva's comment in that PR:

"Add checkbox as per Alex request:

`Could you add a checkbox to the SessionRecording component?   Below the "Output frames" checkbox, but it is only visible if the "Output frames" is checked.  Text is "Wait for Globe Loading" with info box "If this is checked, the session recording will pause the rendering while images on Globes are loading. While this usually works well, it might cause the application to freeze if a data provider is unavailable".    The checkbox should be off by default and when someone presses "Play", the checkbox state gets passed as the last parameter in the startPlayback function. So openspace.sessionRecording.startPlayback("issue2593.osrec",false) would become openspace.sessionRecording.startPlayback("issue2593.osrec",false,false) if the new checkbox is disabled. `

This is branched from the linting branch so it needs to be merged after merging in linting"