### PR TITLE
Add wait for globe rendering checkbox (commit from PR #144)

### DIFF
--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -24,7 +24,7 @@ import Select from '../common/Input/Select/Select';
 import MaterialIcon from '../common/MaterialIcon/MaterialIcon';
 import Popover from '../common/Popover/Popover';
 import Row from '../common/Row/Row';
-
+import PropertyLabel from '../Sidebar/Properties/PropertyLabel';
 import Picker from './Picker';
 
 import styles from './SessionRec.scss';
@@ -247,17 +247,11 @@ function SessionRec() {
       .map((fname) => ({ value: fname, label: fname }));
 
     const fileNameLabel = <span>Name of recording</span>;
-    const fpsLabel = (
-      <span>
-        FPS
-        {' '}
-        <InfoBox
-          className={styles.infoBox}
-          text="The number of frames that will be outputted per second in the saved recording"
-        />
-      </span>
-    );
-    const textFormatLabel = <span>Text file format</span>;
+    const fpsDescription = {
+      Name: "FPS",
+      description: "The number of frames that will be outputted per second in the saved recording"
+    };
+    const fpsLabel = <PropertyLabel description={fpsDescription} />;
 
     return (
       <Popover
@@ -272,7 +266,7 @@ function SessionRec() {
             checked={useTextFormat}
             setChecked={setUseTextFormat}
           >
-            <p>{textFormatLabel}</p>
+            <p>Text file format</p>
           </Checkbox>
           <Row>
             <Input

--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -38,6 +38,7 @@ function SessionRec() {
   const [outputFramerate, setOutputFramerate] = React.useState(60);
   const [loopPlayback, setLoopPlayback] = React.useState(false);
   const [showPopover, setShowPopover] = React.useState(false);
+  const [waitForGlobeRendering, setWaitForGlobeRendering] = React.useState(false);
 
   const luaApi = useSelector((state) => state.luaApi);
 
@@ -119,7 +120,7 @@ function SessionRec() {
       luaApi.sessionRecording.enableTakeScreenShotDuringPlayback(parseInt(outputFramerate, 10));
     }
     if (forceTime) {
-      luaApi.sessionRecording.startPlayback(filenamePlayback, loopPlayback);
+      luaApi.sessionRecording.startPlayback(filenamePlayback, loopPlayback, waitForGlobeRendering);
     } else {
       luaApi.sessionRecording.startPlaybackRecordedTime(filenamePlayback, loopPlayback);
     }
@@ -312,8 +313,8 @@ function SessionRec() {
               <p>Output frames</p>
               <InfoBox
                 className={styles.infoBox}
-                text={`If checked, the specified number of frames will be recorded as 
-                screenshots and saved to disk. Per default, they are saved in the  
+                text={`If checked, the specified number of frames will be recorded as
+                screenshots and saved to disk. Per default, they are saved in the
                 user/screenshots folder. This feature can not be used together with
                 'loop playback'`}
               />
@@ -329,6 +330,21 @@ function SessionRec() {
               />
             )}
           </Row>
+          {shouldOutputFrames && (
+            <Checkbox
+              checked={waitForGlobeRendering}
+              setChecked={setWaitForGlobeRendering}
+              name="waitForGlobeRendering"
+            >
+              <p>Wait for Globe Loading</p>
+              <InfoBox
+                className={styles.infoBox}
+                text={`If this is checked, the session recording will pause the rendering
+                    while images on Globes are loading. While this usually works well, it might
+                    cause the application to freeze if a data provider is unavailable`}
+              />
+            </Checkbox>
+          )}
           <Row>
             <Select
               menuPlacement="top"

--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -38,7 +38,7 @@ function SessionRec() {
   const [outputFramerate, setOutputFramerate] = React.useState(60);
   const [loopPlayback, setLoopPlayback] = React.useState(false);
   const [showPopover, setShowPopover] = React.useState(false);
-  const [waitForGlobeRendering, setWaitForGlobeRendering] = React.useState(false);
+  const [waitForGlobeRendering, setWaitForGlobeRendering] = React.useState(true);
 
   const luaApi = useSelector((state) => state.luaApi);
 

--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -38,7 +38,7 @@ function SessionRec() {
   const [outputFramerate, setOutputFramerate] = React.useState(60);
   const [loopPlayback, setLoopPlayback] = React.useState(false);
   const [showPopover, setShowPopover] = React.useState(false);
-  const [waitForGlobeRendering, setWaitForGlobeRendering] = React.useState(true);
+  const [waitForGlobeRendering, setWaitForGlobeRendering] = React.useState(false);
 
   const luaApi = useSelector((state) => state.luaApi);
 

--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -247,7 +247,16 @@ function SessionRec() {
       .map((fname) => ({ value: fname, label: fname }));
 
     const fileNameLabel = <span>Name of recording</span>;
-    const fpsLabel = <span>FPS</span>;
+    const fpsLabel = (
+      <span>
+        FPS
+        {' '}
+        <InfoBox
+          className={styles.infoBox}
+          text="The number of frames that will be outputted per second in the saved recording"
+        />
+      </span>
+    );
     const textFormatLabel = <span>Text file format</span>;
 
     return (
@@ -303,7 +312,7 @@ function SessionRec() {
           >
             <p>Loop playback</p>
           </Checkbox>
-          <Row className={styles.lastRow}>
+          <Row>
             <Checkbox
               checked={shouldOutputFrames}
               name="outputFramesInput"
@@ -319,31 +328,37 @@ function SessionRec() {
                 'loop playback'`}
               />
             </Checkbox>
-            {shouldOutputFrames && (
-              <Input
-                value={outputFramerate}
-                label={fpsLabel}
-                placeholder="framerate"
-                className={styles.fpsInput}
-                visible={shouldOutputFrames ? 'visible' : 'hidden'}
-                onChange={(evt) => updateOutputFramerate(evt)}
-              />
-            )}
           </Row>
           {shouldOutputFrames && (
-            <Checkbox
-              checked={waitForGlobeRendering}
-              setChecked={setWaitForGlobeRendering}
-              name="waitForGlobeRendering"
-            >
-              <p>Wait for Globe Loading</p>
-              <InfoBox
-                className={styles.infoBox}
-                text={`If this is checked, the session recording will pause the rendering
-                    while images on Globes are loading. While this usually works well, it might
-                    cause the application to freeze if a data provider is unavailable`}
-              />
-            </Checkbox>
+            <>
+              <Row>
+                <span className={styles.checkBoxGroupIndent} />
+                <Input
+                  value={outputFramerate}
+                  label={fpsLabel}
+                  placeholder="framerate"
+                  className={styles.fpsInput}
+                  visible={shouldOutputFrames ? 'visible' : 'hidden'}
+                  onChange={(evt) => updateOutputFramerate(evt)}
+                />
+              </Row>
+              <Row>
+                <span className={styles.checkBoxGroupIndent} />
+                <Checkbox
+                  checked={waitForGlobeRendering}
+                  setChecked={setWaitForGlobeRendering}
+                  name="waitForGlobeRendering"
+                >
+                  <p>Wait for Globe loading</p>
+                  <InfoBox
+                    className={styles.infoBox}
+                    text={`If this is checked, the session recording will pause the rendering
+                      while images on Globes are loading. While this usually works well, it might
+                      cause the application to freeze if a data provider is unavailable`}
+                  />
+                </Checkbox>
+              </Row>
+            </>
           )}
           <Row>
             <Select

--- a/src/components/BottomBar/SessionRec.scss
+++ b/src/components/BottomBar/SessionRec.scss
@@ -9,16 +9,15 @@
 }
 
 .fpsInput {
-  min-width: 40%;
+  max-width: 30%;
 }
 
 .fpsCheckbox {
   min-width: 70%;
 }
 
-.lastRow {
-  margin-bottom: 10px;
-  height: 2em;
+.checkBoxGroupIndent {
+  width: 1.4em;
 }
 
 .infoBox {


### PR DESCRIPTION
But applied on the updated SessionRecording code, that hade been rewritten quite a bit as part of the linting updates

Replaces PR https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/pull/144 (I just copied over the code from @ylvaselling's commit)

Ylva's comment in that PR:

"Add checkbox as per Alex request:

`Could you add a checkbox to the SessionRecording component?   Below the "Output frames" checkbox, but it is only visible if the "Output frames" is checked.  Text is "Wait for Globe Loading" with info box "If this is checked, the session recording will pause the rendering while images on Globes are loading. While this usually works well, it might cause the application to freeze if a data provider is unavailable".    The checkbox should be off by default and when someone presses "Play", the checkbox state gets passed as the last parameter in the startPlayback function. So openspace.sessionRecording.startPlayback("issue2593.osrec",false) would become openspace.sessionRecording.startPlayback("issue2593.osrec",false,false) if the new checkbox is disabled.`

This is branched from the linting branch so it needs to be merged after merging in linting"e