### PR TITLE
Feature/improve node meta

### DIFF
--- a/src/components/NodeMetaPanel/NodeMetaPanel.jsx
+++ b/src/components/NodeMetaPanel/NodeMetaPanel.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { removeNodeMetaPopover, setPopoverActiveTab } from '../../api/Actions';
-import { openUrl } from '../../utils/helpers';
+import { copyTextToClipboard, openUrl } from '../../utils/helpers';
 import Picker from '../BottomBar/Picker';
 import InfoBox from '../common/InfoBox/InfoBox';
 import Button from '../common/Input/Button/Button';
@@ -103,9 +103,7 @@ function NodeMetaPanel({ uri }) {
           </Button>
 
           <Button
-            onClick={() => {
-              navigator.clipboard.writeText(documentation.path);
-            }}
+            onClick={() => copyTextToClipboard(documentation.path)}
             style={{ width: '30%', marginLeft: '0.5em' }}
           >
             Copy Asset File Path

--- a/src/components/NodeMetaPanel/NodeMetaPanel.jsx
+++ b/src/components/NodeMetaPanel/NodeMetaPanel.jsx
@@ -17,6 +17,7 @@ function NodeMetaPanel({ uri }) {
   const showPopover = myPopover ? myPopover.visible : false;
   const attached = myPopover ? myPopover.attached : false;
   const activeTab = myPopover && myPopover.activeTab ? myPopover.activeTab : 0;
+  const isShowingFirstTab = activeTab === 0;
 
   // Find name, gui description and documentation
   const nodeName = useSelector((state) => state.propertyTree.propertyOwners[uri]?.name);
@@ -33,12 +34,9 @@ function NodeMetaPanel({ uri }) {
 
   const documentation = useSelector((state) => {
     const identifier = uri.split('.').pop(); // Get last word in uri
-    const foundDoc = state.documentation.data.find((doc) => {
-      if (doc?.identifiers && doc.identifiers.includes(identifier)) {
-        return true;
-      }
-      return false;
-    });
+    const foundDoc = state.documentation.data.find(
+      (doc) => doc?.identifiers && doc.identifiers.includes(identifier)
+    );
     return foundDoc;
   });
 
@@ -60,7 +58,7 @@ function NodeMetaPanel({ uri }) {
 
   function contentForTab() {
     // GUI Description tag
-    if (activeTab === 0) {
+    if (isShowingFirstTab) {
       return (
         <Row>
           <div className={styles.description_container}>
@@ -121,7 +119,8 @@ function NodeMetaPanel({ uri }) {
   }
 
   function popover() {
-    const windowTitle = `${nodeName} - Object Details`;
+    const titleAddition = isShowingFirstTab ? 'Description' : 'Asset Information';
+    const windowTitle = `${nodeName} - ${titleAddition}`;
     return (
       <Popover
         className={`${Picker.Popover} && ${styles.nodePopover}`}
@@ -138,19 +137,17 @@ function NodeMetaPanel({ uri }) {
         <div className={`${Popover.styles.row} ${Popover.styles.content}`}>
           <Button
             block
-            largetext={activeTab === 0}
-            smalltext={activeTab !== 0}
             key={0}
             onClick={() => setActiveTab(0)}
+            style={!isShowingFirstTab ? { opacity: 0.5 } : {}}
           >
             Description
           </Button>
           <Button
             block
-            largetext={activeTab === 1}
-            smalltext={activeTab !== 0}
             key={1}
             onClick={() => setActiveTab(1)}
+            style={isShowingFirstTab ? { opacity: 0.5 } : {}}
           >
             Asset Info
           </Button>

--- a/src/components/NodeMetaPanel/NodeMetaPanel.jsx
+++ b/src/components/NodeMetaPanel/NodeMetaPanel.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { removeNodeMetaPopover, setPopoverActiveTab } from '../../api/Actions';
 import { openUrl } from '../../utils/helpers';
 import Picker from '../BottomBar/Picker';
+import InfoBox from '../common/InfoBox/InfoBox';
 import Button from '../common/Input/Button/Button';
 import Popover from '../common/Popover/Popover';
 import Row from '../common/Row/Row';
@@ -58,7 +59,7 @@ function NodeMetaPanel({ uri }) {
   }
 
   function contentForTab() {
-    // Description tag
+    // GUI Description tag
     if (activeTab === 0) {
       return (
         <Row>
@@ -68,6 +69,7 @@ function NodeMetaPanel({ uri }) {
         </Row>
       );
     }
+
     // Asset meta info tab
     if (!documentation) {
       return (
@@ -78,7 +80,7 @@ function NodeMetaPanel({ uri }) {
     }
 
     return (
-      <div>
+      <div className={styles.description_container}>
         <Row>
           {`Author: ${documentation.author}`}
         </Row>
@@ -88,18 +90,38 @@ function NodeMetaPanel({ uri }) {
         <Row>
           {`License: ${documentation.license.replace(/\\n/g, '')}`}
         </Row>
-        <Button
-          onClick={() => openUrl(documentation.url)}
-          style={{ width: '100%' }}
-        >
-          Open URL
-        </Button>
+        <Row>
+          {`Description: ${documentation.description}`}
+        </Row>
+        <Row className={styles.assetInfoLastRow}>
+
+          <Button
+            onClick={() => openUrl(documentation.url)}
+            style={{ width: '30%' }}
+          >
+            Open URL
+            {' '}
+            <InfoBox text={`${documentation.url}`} />
+          </Button>
+
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(documentation.path);
+            }}
+            style={{ width: '30%', marginLeft: '0.5em' }}
+          >
+            Copy Asset File Path
+            {' '}
+            <InfoBox text={`${documentation.path}`} />
+          </Button>
+
+        </Row>
       </div>
     );
   }
 
   function popover() {
-    const windowTitle = `${nodeName}- Asset Infomation`;
+    const windowTitle = `${nodeName} - Object Details`;
     return (
       <Popover
         className={`${Picker.Popover} && ${styles.nodePopover}`}
@@ -109,7 +131,7 @@ function NodeMetaPanel({ uri }) {
         detachable
       >
         <div className={`${Popover.styles.content} ${styles.contentContainer}`}>
-          { contentForTab() }
+          {contentForTab()}
         </div>
         <hr className={Popover.styles.delimiter} />
 
@@ -130,7 +152,7 @@ function NodeMetaPanel({ uri }) {
             key={1}
             onClick={() => setActiveTab(1)}
           >
-            Info
+            Asset Info
           </Button>
         </div>
       </Popover>
@@ -139,7 +161,7 @@ function NodeMetaPanel({ uri }) {
 
   return (
     <div className={Picker.Wrapper}>
-      { showPopover && popover() }
+      {showPopover && popover()}
     </div>
   );
 }

--- a/src/components/NodeMetaPanel/NodeMetaPanel.jsx
+++ b/src/components/NodeMetaPanel/NodeMetaPanel.jsx
@@ -92,7 +92,6 @@ function NodeMetaPanel({ uri }) {
           {`Description: ${documentation.description}`}
         </Row>
         <Row className={styles.assetInfoLastRow}>
-
           <Button
             onClick={() => openUrl(documentation.url)}
             style={{ width: '30%' }}
@@ -101,7 +100,6 @@ function NodeMetaPanel({ uri }) {
             {' '}
             <InfoBox text={`${documentation.url}`} />
           </Button>
-
           <Button
             onClick={() => copyTextToClipboard(documentation.path)}
             style={{ width: '30%', marginLeft: '0.5em' }}
@@ -110,7 +108,6 @@ function NodeMetaPanel({ uri }) {
             {' '}
             <InfoBox text={`${documentation.path}`} />
           </Button>
-
         </Row>
       </div>
     );

--- a/src/components/NodeMetaPanel/NodeMetaPanel.scss
+++ b/src/components/NodeMetaPanel/NodeMetaPanel.scss
@@ -10,16 +10,21 @@
 }
 
 .copyButton {
-    padding-left:20px;
+  padding-left: 20px;
 }
 
 .description_container {
-    padding:10px;
-    size: 20px;
+  padding: 10px;
+  size: 20px;
+  width: 100%;
 }
 
 .pad_span {
-    padding-left:5px;
-    max-width: 400px;
-    word-break: break-word;
+  padding-left: 5px;
+  max-width: 400px;
+  word-break: break-word;
+}
+
+.assetInfoLastRow {
+  margin-top: 1em;
 }

--- a/src/components/Sidebar/Properties/PropertyOwnerHeader.jsx
+++ b/src/components/Sidebar/Properties/PropertyOwnerHeader.jsx
@@ -233,7 +233,7 @@ function PropertyOwnerHeader({
     <Button className={styles.menuButton} onClick={metaClick}>
       <Icon icon="material-symbols:help-outline" />
       {' '}
-      Show asset information
+      Show object details
     </Button>
   );
 

--- a/src/components/common/Tooltip/Tooltip.scss
+++ b/src/components/common/Tooltip/Tooltip.scss
@@ -15,6 +15,9 @@ $background: $ui-background-solid;
   white-space: normal;
   z-index: 10;
   font-family: $font-family;
+
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 // placement

--- a/src/components/common/Tooltip/Tooltip.scss
+++ b/src/components/common/Tooltip/Tooltip.scss
@@ -15,7 +15,6 @@ $background: $ui-background-solid;
   white-space: normal;
   z-index: 10;
   font-family: $font-family;
-
   word-wrap: break-word;
   overflow-wrap: break-word;
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -51,3 +51,34 @@ export function stopEventPropagation(e) {
     if (event.stopPropagation) event.stopPropagation();
   }
 }
+
+/**
+ * Copy a text to the clipboard
+ * @param text - text to copy
+ */
+export function copyTextToClipboard(text) {
+  // Note: Implementation is kind of ugly, but works with CEF.
+  // (The preferred "navigator.clipboard.writeText" only works over https)
+  const textArea = document.createElement('textarea');
+  textArea.style.position = 'fixed';
+  textArea.style.top = 0;
+  textArea.style.left = 0;
+
+  textArea.style.width = '2em';
+  textArea.style.height = '2em';
+
+  textArea.style.padding = 0;
+
+  textArea.style.border = 'none';
+  textArea.style.outline = 'none';
+  textArea.style.boxShadow = 'none';
+
+  textArea.value = text;
+
+  document.body.appendChild(textArea);
+
+  textArea.select();
+  document.execCommand('copy');
+
+  document.body.removeChild(textArea);
+}


### PR DESCRIPTION
I found it a bit confusing to get what information in the node meta panel came from the asset VS the GUI description, so made some changes that reflect it better. Also did some small style updates

In the "Asset Info" part I also added :
* The description from the asset file
* A button to copy the asset file path to clipboard

This is how they look after the change
![image](https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/assets/8808894/7dcdc562-4c30-4584-aa27-b74ba843452f)
![image](https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/assets/8808894/e5dd2096-ad73-4367-ab4b-3af5ad80a936)


Also renamed the button to access the panel: 
![image](https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/assets/8808894/58574d65-b794-4d49-b47c-39e5c0d7e6b1)

