### PR TITLE
Issue/2768 - Actions trigger twice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "d3-scale": "^4.0.2",
         "eslint-plugin-simple-import-sort": "^10.0.0",
         "lodash": "^4.17.21",
-        "openspace-api-js": "^0.1.5",
+        "openspace-api-js": "^0.1.6",
         "prop-types": "^15.7.2",
         "re-resizable": "^6.9.9",
         "react": "^18.2.0",
@@ -6898,9 +6898,9 @@
       }
     },
     "node_modules/openspace-api-js": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/openspace-api-js/-/openspace-api-js-0.1.5.tgz",
-      "integrity": "sha512-nJt9nD32E3WnJgNs9zbSBo6WcG4LC+SmT9nzVWgnyY7+5RvtsgC+tH6Rrz2eRFEWVS+Z8dWYBvX6WFxnDTUMiw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/openspace-api-js/-/openspace-api-js-0.1.6.tgz",
+      "integrity": "sha512-1pqd4G8AXnXwWeRikk2uTS1Rk7xAiezI+ivfg1I803D2nvOrXLiAh0mLanDZRS0YC2c/dgdTlmepsOCCGpWZ7w==",
       "dependencies": {
         "core-js": "^3.1.3",
         "regenerator-runtime": "^0.13.2"
@@ -14956,9 +14956,9 @@
       }
     },
     "openspace-api-js": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/openspace-api-js/-/openspace-api-js-0.1.5.tgz",
-      "integrity": "sha512-nJt9nD32E3WnJgNs9zbSBo6WcG4LC+SmT9nzVWgnyY7+5RvtsgC+tH6Rrz2eRFEWVS+Z8dWYBvX6WFxnDTUMiw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/openspace-api-js/-/openspace-api-js-0.1.6.tgz",
+      "integrity": "sha512-1pqd4G8AXnXwWeRikk2uTS1Rk7xAiezI+ivfg1I803D2nvOrXLiAh0mLanDZRS0YC2c/dgdTlmepsOCCGpWZ7w==",
       "requires": {
         "core-js": "^3.1.3",
         "regenerator-runtime": "^0.13.2"

--- a/src/components/BottomBar/Actions/ActionsButton.jsx
+++ b/src/components/BottomBar/Actions/ActionsButton.jsx
@@ -18,8 +18,6 @@ export default function ActionsButton({ action, className }) {
   function sendAction(e) {
     const actionId = e.currentTarget.getAttribute('actionid');
 
-    // Note that we never want to sync the script that triggers an action.
-    // The syncing should be handled by the core code, based on the action details
     const script = `openspace.action.triggerAction('${actionId}')`;
     const shouldSyncScript = !isLocal;
     api.executeLuaScript(script, false, shouldSyncScript);

--- a/src/components/BottomBar/Actions/ActionsButton.jsx
+++ b/src/components/BottomBar/Actions/ActionsButton.jsx
@@ -21,7 +21,7 @@ export default function ActionsButton({ action, className }) {
     // Note that we never want to sync the script that triggers an action.
     // The syncing should be handled by the core code, based on the action details
     const script = `openspace.action.triggerAction('${actionId}')`;
-    const shouldSyncScript = false;
+    const shouldSyncScript = !isLocal;
     api.executeLuaScript(script, false, shouldSyncScript);
   }
 

--- a/src/components/BottomBar/Actions/ActionsButton.jsx
+++ b/src/components/BottomBar/Actions/ActionsButton.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { MdLaunch } from 'react-icons/md';
-import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import api from '../../../api/api';
 import InfoBox from '../../common/InfoBox/InfoBox';
 import Button from '../../common/Input/Button/Button';
 
@@ -13,14 +13,17 @@ export default function ActionsButton({ action, className }) {
     return null;
   }
 
-  const luaApi = useSelector((state) => state.luaApi);
+  const isLocal = (action.synchronization === false);
 
   function sendAction(e) {
     const actionId = e.currentTarget.getAttribute('actionid');
-    luaApi.action.triggerAction(actionId);
-  }
 
-  const isLocal = (action.synchronization === false);
+    // Note that we never want to sync the script that triggers an action.
+    // The syncing should be handled by the core code, based on the action details
+    const script = `openspace.action.triggerAction('${actionId}')`;
+    const shouldSyncScript = false;
+    api.executeLuaScript(script, false, shouldSyncScript);
+  }
 
   return (
     <Button


### PR DESCRIPTION
Helping @Roxeena with OpenSpace/OpenSpace#2768

This upgrades the openspace-api-js package used for triggering the actions, to a version that allows specifying whether the action should be synced or not