### PR TITLE
Feature/more focus options

### DIFF
--- a/src/api/keys.js
+++ b/src/api/keys.js
@@ -7,6 +7,11 @@ export const RetargetAimKey = 'NavigationHandler.OrbitalNavigator.RetargetAim';
 export const RotationalFrictionKey = 'NavigationHandler.OrbitalNavigator.Friction.RotationalFriction';
 export const ZoomFrictionKey = 'NavigationHandler.OrbitalNavigator.Friction.ZoomFriction';
 export const RollFrictionKey = 'NavigationHandler.OrbitalNavigator.Friction.RollFriction';
+
+export const ApplyIdleBehaviorOnPathFinishKey = 'NavigationHandler.PathNavigator.ApplyIdleBehaviorOnFinish';
+export const CameraPathArrivalDistanceFactorKey = 'NavigationHandler.PathNavigator.ArrivalDistanceFactor';
+export const CameraPathSpeedFactorKey = 'NavigationHandler.PathNavigator.SpeedScale';
+
 // To get any scene graph node you need ScenePrefix+NodeIdentifier
 export const ScenePrefixKey = 'Scene.';
 export const SceneKey = 'Scene';

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -7,9 +7,12 @@ import {
 } from 'react-icons/md';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+// eslint-disable-next-line import/no-webpack-loader-syntax
+import Focus from 'svg-react-loader?name=Focus!../../../icons/focus.svg';
 
 import Button from '../../common/Input/Button/Button';
 import Row from '../../common/Row/Row';
+import SvgIcon from '../../common/SvgIcon/SvgIcon';
 import TooltipMenu from '../../common/Tooltip/TooltipMenu';
 import { useContextRefs } from '../../GettingStartedTour/GettingStartedContext';
 
@@ -55,7 +58,7 @@ function FocusEntry({
     closePopoverIfSet();
   };
 
-  const fadeToFocus = async (event) => {
+  const fadeTo = async (event) => {
     event.stopPropagation();
     const fadeTime = 1;
     const promise = new Promise((resolve) => {
@@ -92,13 +95,19 @@ function FocusEntry({
           <TooltipMenu
             sourceObject={<MdMoreVert className={styles.buttonIcon} />}
           >
+            <Button className={styles.flyToButton} onClick={select} title="Focus">
+              <Row>
+                <SvgIcon className={styles.buttonIcon}><Focus /></SvgIcon>
+                <span className={styles.verticallyCentered}> Focus </span>
+              </Row>
+            </Button>
             <Button className={styles.flyToButton} onClick={flyTo} title="Fly to">
               <Row>
                 <MdFlight className={styles.buttonIcon} />
                 <span className={styles.verticallyCentered}> Fly to </span>
               </Row>
             </Button>
-            <Button className={styles.flyToButton} onClick={fadeToFocus} title="Fade to">
+            <Button className={styles.flyToButton} onClick={fadeTo} title="Fade to">
               <Row>
                 <MdFlashOn className={styles.buttonIcon} />
                 <span className={styles.verticallyCentered}> Jump to </span>

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -15,6 +15,7 @@ import {
   CameraPathArrivalDistanceFactorKey,
   CameraPathSpeedFactorKey
 } from '../../../api/keys';
+import InfoBox from '../../common/InfoBox/InfoBox';
 import Button from '../../common/Input/Button/Button';
 import Popover from '../../common/Popover/Popover';
 import Row from '../../common/Row/Row';
@@ -60,10 +61,20 @@ function FocusEntry({
 
   const zoomToFocus = (event) => {
     if (event.shiftKey) {
-      luaApi.pathnavigation.zoomToFocus(0.0);
+      luaApi.pathnavigation.createPath({
+        TargetType: 'Node',
+        Target: identifier,
+        Duration: 0,
+        PathType: 'Linear'
+      });
     } else {
-      luaApi.pathnavigation.zoomToFocus();
+      luaApi.pathnavigation.createPath({
+        TargetType: 'Node',
+        Target: identifier,
+        PathType: 'Linear'
+      });
     }
+
     event.stopPropagation();
     closePopoverIfSet();
   };
@@ -123,11 +134,14 @@ function FocusEntry({
                 <span className={styles.verticallyCentered}> Jump to </span>
               </Row>
             </Button>
-            {/* TODO: Make it zoom to any node */}
             <Button className={styles.flyToButton} onClick={zoomToFocus} title="Zoom to">
               <Row>
                 <MdCenterFocusStrong className={styles.buttonIcon} />
                 <span className={styles.verticallyCentered}> Zoom to / Frame </span>
+                <InfoBox
+                  text={`Focus on the target object by moving the camera in a straigt line
+                  and rotate towards the object`}
+                />
               </Row>
             </Button>
             <ToggleContent

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import Focus from 'svg-react-loader?name=Focus!../../../icons/focus.svg';
 
 import Button from '../../common/Input/Button/Button';
+import Popover from '../../common/Popover/Popover';
 import Row from '../../common/Row/Row';
 import SvgIcon from '../../common/SvgIcon/SvgIcon';
 import TooltipMenu from '../../common/Tooltip/TooltipMenu';
@@ -101,6 +102,7 @@ function FocusEntry({
                 <span className={styles.verticallyCentered}> Focus </span>
               </Row>
             </Button>
+            <hr className={Popover.styles.delimiter} />
             <Button className={styles.flyToButton} onClick={flyTo} title="Fly to">
               <Row>
                 <MdFlight className={styles.buttonIcon} />
@@ -113,6 +115,7 @@ function FocusEntry({
                 <span className={styles.verticallyCentered}> Jump to </span>
               </Row>
             </Button>
+            {/* TODO: Make it zoom to any node */}
             <Button className={styles.flyToButton} onClick={zoomToFocus} title="Zoom to">
               <Row>
                 <MdCenterFocusStrong className={styles.buttonIcon} />

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -19,6 +19,7 @@ import InfoBox from '../../common/InfoBox/InfoBox';
 import Button from '../../common/Input/Button/Button';
 import Popover from '../../common/Popover/Popover';
 import Row from '../../common/Row/Row';
+import SmallLabel from '../../common/SmallLabel/SmallLabel';
 import SvgIcon from '../../common/SvgIcon/SvgIcon';
 import ToggleContent from '../../common/ToggleContent/ToggleContent';
 import TooltipMenu from '../../common/Tooltip/TooltipMenu';
@@ -115,6 +116,8 @@ function FocusEntry({
           <TooltipMenu
             sourceObject={<MdMoreVert className={styles.buttonIcon} />}
           >
+            <SmallLabel className={styles.menuTopLabel}>{identifier}</SmallLabel>
+            <hr className={Popover.styles.delimiter} />
             <Button className={styles.flyToButton} onClick={select} title="Focus">
               <Row>
                 <SvgIcon className={styles.buttonIcon}><Focus /></SvgIcon>

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { MdCenterFocusStrong, MdFlight } from 'react-icons/md';
+import {
+  MdCenterFocusStrong,
+  MdFlashOn,
+  MdFlight,
+  MdMoreVert
+} from 'react-icons/md';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import Button from '../../common/Input/Button/Button';
+import Row from '../../common/Row/Row';
+import TooltipMenu from '../../common/Tooltip/TooltipMenu';
 import { useContextRefs } from '../../GettingStartedTour/GettingStartedContext';
 
 import styles from './FocusEntry.scss';
@@ -48,6 +55,20 @@ function FocusEntry({
     closePopoverIfSet();
   };
 
+  const fadeToFocus = async (event) => {
+    event.stopPropagation();
+    const fadeTime = 1;
+    const promise = new Promise((resolve) => {
+      luaApi.setPropertyValueSingle('RenderEngine.BlackoutFactor', 0, fadeTime, 'QuadraticEaseOut');
+      setTimeout(() => resolve('done!'), fadeTime * 1000);
+    });
+    await promise;
+    luaApi.pathnavigation.flyTo(identifier, 0.0);
+    luaApi.setPropertyValueSingle('RenderEngine.BlackoutFactor', 1, fadeTime, 'QuadraticEaseIn');
+    event.stopPropagation();
+    closePopoverIfSet();
+  };
+
   const refs = useContextRefs();
 
   return (
@@ -65,14 +86,31 @@ function FocusEntry({
       </span>
       {showNavigationButtons && (
         <div className={styles.buttonContainer}>
-          { isActive() && (
-            <Button className={styles.flyToButton} onClick={zoomToFocus} title="Zoom to">
-              <MdCenterFocusStrong className={styles.buttonIcon} />
-            </Button>
-          )}
-          <Button className={styles.flyToButton} onClick={flyTo} title="Fly to">
+          <Button onClick={flyTo} title="Fly to">
             <MdFlight className={styles.buttonIcon} />
           </Button>
+          <TooltipMenu
+            sourceObject={<MdMoreVert className={styles.buttonIcon} />}
+          >
+            <Button className={styles.flyToButton} onClick={flyTo} title="Fly to">
+              <Row>
+                <MdFlight className={styles.buttonIcon} />
+                <span className={styles.verticallyCentered}> Fly to </span>
+              </Row>
+            </Button>
+            <Button className={styles.flyToButton} onClick={fadeToFocus} title="Fade to">
+              <Row>
+                <MdFlashOn className={styles.buttonIcon} />
+                <span className={styles.verticallyCentered}> Jump to </span>
+              </Row>
+            </Button>
+            <Button className={styles.flyToButton} onClick={zoomToFocus} title="Zoom to">
+              <Row>
+                <MdCenterFocusStrong className={styles.buttonIcon} />
+                <span className={styles.verticallyCentered}> Zoom to / Frame </span>
+              </Row>
+            </Button>
+          </TooltipMenu>
         </div>
       )}
     </div>

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -111,6 +111,7 @@ function FocusEntry({
       {showNavigationButtons && (
         <div className={styles.buttonContainer}>
           <Button onClick={flyTo} title="Fly to">
+          <Button className={styles.quickAccessFlyTo} onClick={flyTo} title="Fly to">
             <MdFlight className={styles.buttonIcon} />
           </Button>
           <TooltipMenu
@@ -121,26 +122,26 @@ function FocusEntry({
             <Button className={styles.flyToButton} onClick={select} title="Focus">
               <Row>
                 <SvgIcon className={styles.buttonIcon}><Focus /></SvgIcon>
-                <span className={styles.verticallyCentered}> Focus </span>
+                <span className={styles.menuButtonLabel}> Focus </span>
               </Row>
             </Button>
             <hr className={Popover.styles.delimiter} />
             <Button className={styles.flyToButton} onClick={flyTo} title="Fly to">
               <Row>
                 <MdFlight className={styles.buttonIcon} />
-                <span className={styles.verticallyCentered}> Fly to </span>
+                <span className={styles.menuButtonLabel}> Fly to </span>
               </Row>
             </Button>
             <Button className={styles.flyToButton} onClick={fadeTo} title="Fade to">
               <Row>
                 <MdFlashOn className={styles.buttonIcon} />
-                <span className={styles.verticallyCentered}> Jump to </span>
+                <span className={styles.menuButtonLabel}> Jump to </span>
               </Row>
             </Button>
             <Button className={styles.flyToButton} onClick={zoomToFocus} title="Zoom to">
               <Row>
                 <MdCenterFocusStrong className={styles.buttonIcon} />
-                <span className={styles.verticallyCentered}> Zoom to / Frame </span>
+                <span className={styles.menuButtonLabel}> Zoom to / Frame </span>
                 <InfoBox
                   text={`Focus on the target object by moving the camera in a straigt line
                   and rotate towards the object`}

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -110,7 +110,11 @@ function FocusEntry({
       </span>
       {showNavigationButtons && (
         <div className={styles.buttonContainer}>
-          <Button onClick={flyTo} title="Fly to">
+          {isActive() && (
+            <Button className={styles.quickAccessFlyTo} onClick={zoomToFocus} title="Zoom to">
+              <MdCenterFocusStrong className={styles.buttonIcon} />
+            </Button>
+          )}
           <Button className={styles.quickAccessFlyTo} onClick={flyTo} title="Fly to">
             <MdFlight className={styles.buttonIcon} />
           </Button>

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -70,6 +70,7 @@ function FocusEntry({
 
   const fadeTo = async (event) => {
     event.stopPropagation();
+    closePopoverIfSet();
     const fadeTime = 1;
     const promise = new Promise((resolve) => {
       luaApi.setPropertyValueSingle('RenderEngine.BlackoutFactor', 0, fadeTime, 'QuadraticEaseOut');
@@ -78,8 +79,6 @@ function FocusEntry({
     await promise;
     luaApi.pathnavigation.flyTo(identifier, 0.0);
     luaApi.setPropertyValueSingle('RenderEngine.BlackoutFactor', 1, fadeTime, 'QuadraticEaseIn');
-    event.stopPropagation();
-    closePopoverIfSet();
   };
 
   const refs = useContextRefs();

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -10,18 +10,27 @@ import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import Focus from 'svg-react-loader?name=Focus!../../../icons/focus.svg';
 
+import {
+  ApplyIdleBehaviorOnPathFinishKey,
+  CameraPathArrivalDistanceFactorKey,
+  CameraPathSpeedFactorKey
+} from '../../../api/keys';
 import Button from '../../common/Input/Button/Button';
 import Popover from '../../common/Popover/Popover';
 import Row from '../../common/Row/Row';
 import SvgIcon from '../../common/SvgIcon/SvgIcon';
+import ToggleContent from '../../common/ToggleContent/ToggleContent';
 import TooltipMenu from '../../common/Tooltip/TooltipMenu';
 import { useContextRefs } from '../../GettingStartedTour/GettingStartedContext';
+import Property from '../../Sidebar/Properties/Property';
 
 import styles from './FocusEntry.scss';
 
 function FocusEntry({
   name, identifier, onSelect, active, showNavigationButtons, closePopoverIfSet
 }) {
+  const [isSettingsExpanded, setSettingsExpanded] = React.useState(false);
+
   const luaApi = useSelector((state) => state.luaApi);
   function isActive() {
     return identifier === active;
@@ -122,6 +131,15 @@ function FocusEntry({
                 <span className={styles.verticallyCentered}> Zoom to / Frame </span>
               </Row>
             </Button>
+            <ToggleContent
+              title="Camera Path Settings"
+              expanded={isSettingsExpanded}
+              setExpanded={setSettingsExpanded}
+            >
+              <Property uri={CameraPathSpeedFactorKey} />
+              <Property uri={CameraPathArrivalDistanceFactorKey} />
+              <Property uri={ApplyIdleBehaviorOnPathFinishKey} />
+            </ToggleContent>
           </TooltipMenu>
         </div>
       )}

--- a/src/components/BottomBar/Origin/FocusEntry.jsx
+++ b/src/components/BottomBar/Origin/FocusEntry.jsx
@@ -148,7 +148,7 @@ function FocusEntry({
               </Row>
             </Button>
             <ToggleContent
-              title="Camera Path Settings"
+              title="Settings"
               expanded={isSettingsExpanded}
               setExpanded={setSettingsExpanded}
             >

--- a/src/components/BottomBar/Origin/FocusEntry.scss
+++ b/src/components/BottomBar/Origin/FocusEntry.scss
@@ -25,6 +25,7 @@ $icon-size: 18px;
 .buttonIcon {
   @extend .verticallyCentered;
   font-size: $icon-size;
+  vertical-align: middle;
 }
 
 .menuButtonLabel {

--- a/src/components/BottomBar/Origin/FocusEntry.scss
+++ b/src/components/BottomBar/Origin/FocusEntry.scss
@@ -1,6 +1,6 @@
 @import "../../../styles/all";
 
-$icon-size: 21px;
+$icon-size: 18px;
 
 .entry {
   padding: $popover-horizontal-padding;
@@ -27,18 +27,34 @@ $icon-size: 21px;
   font-size: $icon-size;
 }
 
+.menuButtonLabel {
+  margin-top: auto;
+  margin-left: 0.3em;
+}
+
 .buttonContainer {
   position: absolute;
   right: 0;
   top: 50%;
   transform: translateY(-50%);
-
+  padding-top: 3px;
+  padding-bottom: 3px;
   height: 100%;
 
   > * {
-    padding: 0.2em 0.3em 0.1em;
+    height: 100%;
     display: inline-block;
+    vertical-align: top;
+    margin-right: 0.1em;
+    > button {
+      height: 100%;
+    }
   }
+}
+
+.quickAccessFlyTo {
+  padding: 0.1em 0.4em 0.1em;
+  margin-right: 0.3em;
 }
 
 .flyToButton {

--- a/src/components/BottomBar/Origin/FocusEntry.scss
+++ b/src/components/BottomBar/Origin/FocusEntry.scss
@@ -45,3 +45,8 @@ $icon-size: 21px;
   padding: 0.5em 0.7em 0.5em;
   margin: 2px;
 }
+
+.menuTopLabel {
+  margin-left: 3px;
+  color: $text-color-blur;
+}

--- a/src/components/BottomBar/Origin/FocusEntry.scss
+++ b/src/components/BottomBar/Origin/FocusEntry.scss
@@ -1,6 +1,6 @@
 @import "../../../styles/all";
 
-$icon-size: 22px;
+$icon-size: 21px;
 
 .entry {
   padding: $popover-horizontal-padding;
@@ -17,7 +17,13 @@ $icon-size: 22px;
   position: relative;
 }
 
+.verticallyCentered {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
 .buttonIcon {
+  @extend .verticallyCentered;
   font-size: $icon-size;
 }
 
@@ -26,16 +32,16 @@ $icon-size: 22px;
   right: 0;
   top: 50%;
   transform: translateY(-50%);
+
+  height: 100%;
+
+  > * {
+    padding: 0.2em 0.3em 0.1em;
+    display: inline-block;
+  }
 }
 
 .flyToButton {
-  margin-left: 0.3em;
-  padding: 0.2em 0.5em 0.1em;
-  display: none;
-}
-
-/* Show button on hover */
-.entry:hover .flyToButton,
-.entry:active .flyToButton {
-  display: inline-block;
+  padding: 0.5em 0.7em 0.5em;
+  margin: 2px;
 }

--- a/src/components/common/ToggleContent/ToggleContent.jsx
+++ b/src/components/common/ToggleContent/ToggleContent.jsx
@@ -13,8 +13,9 @@ function ToggleContent({
     return null;
   }
 
-  function toggleExpanded() {
+  function toggleExpanded(evt) {
     setExpanded(!expanded);
+    evt.stopPropagation();
   }
 
   return (

--- a/src/components/common/Tooltip/Tooltip.scss
+++ b/src/components/common/Tooltip/Tooltip.scss
@@ -1,7 +1,7 @@
 @import "../../../styles/all";
 
 $arrow-size: 4px;
-$background: $ui-background-solid;
+$background: $ui-background-toplevel;
 
 .tooltip {
   background: $background;

--- a/src/components/common/Tooltip/TooltipMenu.jsx
+++ b/src/components/common/Tooltip/TooltipMenu.jsx
@@ -54,9 +54,12 @@ function TooltipMenu({
   };
 
   return (
+    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events,
+       jsx-a11y/no-static-element-interactions */
     <div
       ref={wrapperRef}
       className={className}
+      onClick={(evt) => { evt.stopPropagation(); }}
     >
       <Button
         ref={buttonClickWrapperRef}

--- a/src/components/common/Tooltip/TooltipMenu.scss
+++ b/src/components/common/Tooltip/TooltipMenu.scss
@@ -3,5 +3,4 @@
 .menuButton {
   height: fit-content;
   background: rgba(0, 0, 0, 0);
-  vertical-align: top;
 }

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -10,9 +10,9 @@ $orange: #FF851B;
 $ui-background-toplevel: $darker-grey;
 $ui-background-solid: $dark-grey;
 $ui-background: rgba($ui-background-solid, 0.9);
-$ui-background-hover: rgba(white, 0.06);
-$ui-background-selected: rgba(white, 0.03);
-$ui-background-active: rgba(white, 0.03);
+$ui-background-hover: rgba(white, 0.08);
+$ui-background-selected: rgba(white, 0.05);
+$ui-background-active: rgba(white, 0.05);
 $ui-background-slider-input: rgba(white, 0.1);
 
 $ui-danger: $red;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,6 +1,6 @@
 // color definitions
 $dark-grey: #181818;
-$darker-grey: #0c0c0c;
+$darker-grey: #101010;
 $yellow: #ebd972;
 $blue: #3DBDEE;
 $red: #FF4136;

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,11 +1,13 @@
 // color definitions
 $dark-grey: #181818;
+$darker-grey: #0c0c0c;
 $yellow: #ebd972;
 $blue: #3DBDEE;
 $red: #FF4136;
 $orange: #FF851B;
 
 // color usage
+$ui-background-toplevel: $darker-grey;
 $ui-background-solid: $dark-grey;
 $ui-background: rgba($ui-background-solid, 0.9);
 $ui-background-hover: rgba(white, 0.06);


### PR DESCRIPTION
Make it so that the navigation button is always visible (more touch friendly), and expose some extra buttons and settings in a "..."-menu.  

Note that the "settings" in this menu is just a quick access to the properties.  Thoughts on that? Does a user understand that this is the case?

Looking for input on the design of the menu, the choice of settings, and also how a similar menu could look in the "..." of the scene graph nodes in the Scene pane :) 

closes https://github.com/OpenSpace/OpenSpace/issues/2925


![image](https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/assets/8808894/f9119048-49a1-41b0-8f80-2b915b2845b7)

