### PR TITLE
Issue/2665 - Show timer for how long time left in camera path

### DIFF
--- a/src/api/Actions/actionTypes.js
+++ b/src/api/Actions/actionTypes.js
@@ -59,6 +59,11 @@ const actionTypes = {
   unsubscribeToCamera: 'CAMERA_UNSUBSCRIBE',
   updateCamera: 'CAMERA_UPDATE',
 
+  // action types for camera path topic
+  subscribeToCameraPath: 'CAMERA_PATH_SUBSCRIBE',
+  unsubscribeToCameraPath: 'CAMERA_PATH_UNSUBSCRIBE',
+  updateCameraPath: 'CAMERA_PATH_UPDATE',
+
   // action types for shortcuts
   subscribeToShortcuts: 'SHORTCUTS_SUBSCRIBE',
   unsubscribeToShortcuts: 'SHORTCUTS_UNSUBSCRIBE',

--- a/src/api/Actions/index.js
+++ b/src/api/Actions/index.js
@@ -254,6 +254,21 @@ export const unsubscribeToCamera = (data) => ({
   payload: data
 });
 
+export const subscribeToCameraPath = (data) => ({
+  type: actionTypes.subscribeToCameraPath,
+  payload: data
+});
+
+export const updateCameraPath = (data) => ({
+  type: actionTypes.updateCameraPath,
+  payload: data
+});
+
+export const unsubscribeToCameraPath = (data) => ({
+  type: actionTypes.unsubscribeToCameraPath,
+  payload: data
+});
+
 export const subscribeToShortcuts = () => ({
   type: actionTypes.subscribeToShortcuts,
   payload: {}

--- a/src/api/Middleware/cameraPath.js
+++ b/src/api/Middleware/cameraPath.js
@@ -1,0 +1,61 @@
+import { updateCameraPath } from '../Actions';
+import actionTypes from '../Actions/actionTypes';
+import api from '../api';
+
+let cameraPathTopic;
+let nSubscribers = 0;
+
+function handleData(store, data) {
+  store.dispatch(updateCameraPath(data));
+}
+
+function tearDownSubscription() {
+  if (!cameraPathTopic) {
+    return;
+  }
+  cameraPathTopic.talk({
+    event: 'stop_subscription'
+  });
+  cameraPathTopic.cancel();
+}
+
+async function setupSubscription(store) {
+  cameraPathTopic = api.startTopic('cameraPath', {
+    event: 'start_subscription'
+  });
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const data of cameraPathTopic.iterator()) {
+    handleData(store, data);
+  }
+}
+
+const cameraPath = (store) => (next) => (action) => {
+  const result = next(action);
+  const state = store.getState();
+  switch (action.type) {
+    case actionTypes.onOpenConnection:
+      if (nSubscribers > 0) {
+        setupSubscription(store);
+      }
+      break;
+    case actionTypes.subscribeToCameraPath:
+      ++nSubscribers;
+      if (nSubscribers === 1 && state.connection.isConnected) {
+        setupSubscription(store);
+      }
+      break;
+    case actionTypes.unsubscribeToCameraPath:
+      if (nSubscribers > 0) {
+        --nSubscribers;
+      }
+      if (cameraPathTopic && nSubscribers === 0) {
+        tearDownSubscription();
+      }
+      break;
+    default:
+      break;
+  }
+  return result;
+};
+
+export default cameraPath;

--- a/src/api/Middleware/index.js
+++ b/src/api/Middleware/index.js
@@ -1,6 +1,7 @@
 import { applyMiddleware } from 'redux';
 
 import camera from './camera';
+import cameraPath from './cameraPath';
 import connection from './connection';
 import documentation from './documentation';
 import engineMode from './engineMode';
@@ -30,7 +31,8 @@ const middleware = applyMiddleware(
   documentation,
   exoplanets,
   skybrowser,
-  camera
+  camera,
+  cameraPath
 );
 
 export default middleware;

--- a/src/api/Reducers/cameraPath.js
+++ b/src/api/Reducers/cameraPath.js
@@ -1,0 +1,24 @@
+import actionTypes from '../Actions/actionTypes';
+
+const defaultState = {
+  target: undefined,
+  remainingTime: undefined,
+  isPaused: undefined
+};
+
+const cameraPath = (state = defaultState, action = {}) => {
+  const newState = { ...state };
+  switch (action.type) {
+    case actionTypes.updateCameraPath:
+      newState.target = action.payload.target;
+      newState.remainingTime = action.payload.remainingTime;
+      newState.isPaused = action.payload.isPaused;
+      return newState;
+    case actionTypes.subscribeToCameraPath:
+      newState.data = action.payload;
+      return newState;
+    default:
+      return state;
+  }
+};
+export default cameraPath;

--- a/src/api/Reducers/index.js
+++ b/src/api/Reducers/index.js
@@ -1,4 +1,5 @@
 import camera from './camera';
+import cameraPath from './cameraPath';
 import connection from './connection';
 import documentation from './documentation';
 import engineMode from './engineMode';
@@ -27,6 +28,7 @@ const openspaceApp = (state = {}, action = {}) => {
     time: time(state.time, action),
     connection: connection(state.connection, action),
     camera: camera(state.camera, action),
+    cameraPath: cameraPath(state.cameraPath, action),
     documentation: documentation(state.documentation, action),
     exoplanets: exoplanets(state.exoplanets, action),
     skybrowser: skybrowser(state.skybrowser, action),

--- a/src/components/BottomBar/Origin/OriginPicker.jsx
+++ b/src/components/BottomBar/Origin/OriginPicker.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MdAirplanemodeInactive } from 'react-icons/md';
+import { MdAirplanemodeInactive, MdFlight } from 'react-icons/md';
 import { useDispatch, useSelector } from 'react-redux';
 /* eslint-disable import/no-webpack-loader-syntax */
 import Aim from 'svg-react-loader?name=Aim!../../../icons/aim.svg';
@@ -11,8 +11,10 @@ import {
   sendFlightControl,
   setNavigationAction,
   setPopoverVisibility,
+  subscribeToCameraPath,
   subscribeToEngineMode,
   subscribeToSessionRecording,
+  unsubscribeToCameraPath,
   unsubscribeToEngineMode,
   unsubscribeToSessionRecording
 } from '../../../api/Actions';
@@ -40,6 +42,7 @@ import Button from '../../common/Input/Button/Button';
 import Checkbox from '../../common/Input/Checkbox/Checkbox';
 import LoadingString from '../../common/LoadingString/LoadingString';
 import Popover from '../../common/Popover/Popover';
+import Row from '../../common/Row/Row';
 import SettingsPopup from '../../common/SettingsPopup/SettingsPopup';
 import SmallLabel from '../../common/SmallLabel/SmallLabel';
 import SvgIcon from '../../common/SvgIcon/SvgIcon';
@@ -114,6 +117,11 @@ function OriginPicker() {
   const sessionRecordingState = useSelector((state) => state.sessionRecording.recordingState);
   const navigationAction = useSelector((state) => state.local.originPicker.action);
 
+  // Camera path information
+  const pathTarget = useSelector((state) => state.cameraPath.target);
+  const remainingTimeForPath = useSelector((state) => state.cameraPath.remainingTime);
+  const isPathPaused = useSelector((state) => state.cameraPath.isPaused);
+
   const dispatch = useDispatch();
   // Use refs so these aren't recalculated each render and trigger useEffect
   const anchorDispatcher = React.useRef(propertyDispatcher(dispatch, NavigationAnchorKey));
@@ -126,9 +134,11 @@ function OriginPicker() {
   React.useEffect(() => {
     dispatch(subscribeToSessionRecording());
     dispatch(subscribeToEngineMode());
+    dispatch(subscribeToCameraPath());
     return () => {
       dispatch(unsubscribeToSessionRecording());
       dispatch(unsubscribeToEngineMode());
+      dispatch(unsubscribeToCameraPath());
     };
   }, []);
 
@@ -268,31 +278,49 @@ function OriginPicker() {
     };
 
     return (
-      <div
-        className={`${styles.Grid} ${styles.cancelButton}`}
-        onClick={cancelFlight}
-        onKeyPress={cancelFlight}
-        role="button"
-        tabIndex={0}
-      >
-        <MdAirplanemodeInactive className={styles.Icon} />
-        <div className={Picker.Title}>
-          <span className={Picker.Name}>
-            <LoadingString loading={anchor === undefined}>
-              Cancel
-            </LoadingString>
-          </span>
-          <div>
-            <SmallLabel>
-              <SvgIcon><Anchor /></SvgIcon>
-              {' '}
-              <LoadingString loading={anchor === undefined}>
+      <>
+        <div
+          className={`${styles.Grid}`}
+          onClick={cancelFlight}
+          onKeyPress={cancelFlight}
+          role="button"
+          tabIndex={0}
+        >
+          <Button
+            className={styles.cancelButton}
+            onClick={cancelFlight}
+            onKeyPress={cancelFlight}
+            wide
+          >
+            <Row className={styles.cancelButtonTitle}>
+              <MdAirplanemodeInactive className={styles.SmallPickerIcon} />
+              {'  Cancel'}
+            </Row>
+            <SmallLabel className={styles.cancelButtonAnchorLabel}>
+              {' ('}
+              <SvgIcon className={styles.SmallPickerIcon}><Anchor /></SvgIcon>
+              <span className={styles.cancelButtonAnchorLabelText}>
                 {cappedAnchorName}
-              </LoadingString>
+              </span>
+              {') '}
+            </SmallLabel>
+          </Button>
+        </div>
+
+        <div className={`${styles.Grid} ${styles.blink}`}>
+          <MdFlight className={`${styles.Icon}`} />
+          <div className={Picker.Title}>
+            <span className={`${Picker.Name}`}>
+              {pathTarget}
+              {/* TODO: should be the name and not identifier */}
+            </span>
+            <SmallLabel>
+              {remainingTimeForPath}
+              {' s'}
             </SmallLabel>
           </div>
         </div>
-      </div>
+      </>
     );
   }
 
@@ -398,7 +426,7 @@ function OriginPicker() {
             title="Select focus"
             transparent={navigationAction !== NavigationActions.Focus}
           >
-            <SvgIcon className={styles.ButtonIcon}><Focus /></SvgIcon>
+            <SvgIcon className={styles.TabIcon}><Focus /></SvgIcon>
           </Button>
           <Button
             className={styles.NavigationButton}
@@ -406,7 +434,7 @@ function OriginPicker() {
             title="Select anchor"
             transparent={navigationAction !== NavigationActions.Anchor}
           >
-            <SvgIcon className={styles.ButtonIcon}><Anchor /></SvgIcon>
+            <SvgIcon className={styles.TabIcon}><Anchor /></SvgIcon>
           </Button>
           <Button
             className={styles.NavigationButton}
@@ -414,7 +442,7 @@ function OriginPicker() {
             title="Select aim"
             transparent={navigationAction !== NavigationActions.Aim}
           >
-            <SvgIcon className={styles.ButtonIcon}><Aim /></SvgIcon>
+            <SvgIcon className={styles.TabIcon}><Aim /></SvgIcon>
           </Button>
         </div>
         <FilterList

--- a/src/components/BottomBar/Origin/OriginPicker.jsx
+++ b/src/components/BottomBar/Origin/OriginPicker.jsx
@@ -118,9 +118,14 @@ function OriginPicker() {
   const navigationAction = useSelector((state) => state.local.originPicker.action);
 
   // Camera path information
-  const pathTarget = useSelector((state) => state.cameraPath.target);
+  const pathTargetNode = useSelector((state) => state.cameraPath.target);
+  const pathTargetNodeName = useSelector((state) => {
+    const node = state.propertyTree.propertyOwners[ScenePrefixKey + pathTargetNode];
+    return node ? node.name : pathTargetNode;
+  });
   const remainingTimeForPath = useSelector((state) => state.cameraPath.remainingTime);
-  const isPathPaused = useSelector((state) => state.cameraPath.isPaused);
+  // @ TODO: Use this, sometime, to communicate when a path is paused
+  // const isPathPaused = useSelector((state) => state.cameraPath.isPaused);
 
   const dispatch = useDispatch();
   // Use refs so these aren't recalculated each render and trigger useEffect
@@ -277,6 +282,8 @@ function OriginPicker() {
       luaApi.pathnavigation.stopPath();
     };
 
+    const pathTargetNodeNameCapped = pathTargetNodeName?.substring(0, 20);
+
     return (
       <>
         <div
@@ -296,7 +303,7 @@ function OriginPicker() {
               <MdAirplanemodeInactive className={styles.SmallPickerIcon} />
               {'  Cancel'}
             </Row>
-            <SmallLabel className={styles.cancelButtonAnchorLabel}>
+            <SmallLabel className={styles.cancelButtonLabel}>
               {' ('}
               <SvgIcon className={styles.SmallPickerIcon}><Anchor /></SvgIcon>
               <span className={styles.cancelButtonAnchorLabelText}>
@@ -308,11 +315,10 @@ function OriginPicker() {
         </div>
 
         <div className={`${styles.Grid} ${styles.blink}`}>
-          <MdFlight className={`${styles.Icon}`} />
+          <MdFlight className={styles.Icon} />
           <div className={Picker.Title}>
-            <span className={`${Picker.Name}`}>
-              {pathTarget}
-              {/* TODO: should be the name and not identifier */}
+            <span className={`${Picker.Name} ${styles.cancelButtonLabel}`}>
+              {pathTargetNodeNameCapped}
             </span>
             <SmallLabel>
               {remainingTimeForPath}

--- a/src/components/BottomBar/Origin/OriginPicker.scss
+++ b/src/components/BottomBar/Origin/OriginPicker.scss
@@ -66,8 +66,8 @@ $small-icon-size: 16px;
 }
 
 .blink {
-  animation: blink 1.5s  infinite;
-  -webkit-animation: blink 1.5s  infinite;
+  animation: blink 2s  infinite;
+  -webkit-animation: blink 2s  infinite;
   animation-fill-mode: both;
 }
 

--- a/src/components/BottomBar/Origin/OriginPicker.scss
+++ b/src/components/BottomBar/Origin/OriginPicker.scss
@@ -8,8 +8,12 @@ $small-icon-size: 16px;
   margin-right: calc($base-padding / 2);
 }
 
-.ButtonIcon {
+.TabIcon {
   font-size: $small-icon-size;
+}
+
+.SmallPickerIcon {
+  margin-right: 0.2em;
 }
 
 .NavigationButton {
@@ -30,4 +34,45 @@ $small-icon-size: 16px;
 
 .Grid {
   display: flex;
+}
+
+.cancelButton {
+  margin-right: calc($base-padding / 2);
+  text-align: center;
+  padding-left: calc($base-padding / 2);
+  padding-right: calc($base-padding / 2);
+
+  > * {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.cancelButtonTitle {
+  margin-bottom: 2px;
+  text-transform: uppercase;
+}
+
+.cancelButtonAnchorLabel {
+  white-space: nowrap;
+}
+
+.cancelButtonAnchorLabelText {
+  vertical-align: middle;
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+}
+
+.blink {
+  animation: blink 1.5s  infinite;
+  -webkit-animation: blink 1.5s  infinite;
+  animation-fill-mode: both;
+}
+
+@keyframes blink {
+  0% { opacity: 0.3 }
+  50% { opacity: 1.0 }
+  100% { opacity: 0.3 }
 }

--- a/src/components/BottomBar/Origin/OriginPicker.scss
+++ b/src/components/BottomBar/Origin/OriginPicker.scss
@@ -41,20 +41,19 @@ $small-icon-size: 16px;
   text-align: center;
   padding-left: calc($base-padding / 2);
   padding-right: calc($base-padding / 2);
-
-  > * {
-    margin-left: auto;
-    margin-right: auto;
-  }
 }
 
 .cancelButtonTitle {
   margin-bottom: 2px;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.cancelButtonAnchorLabel {
+.cancelButtonLabel {
   white-space: nowrap;
+  > * {
+    vertical-align: middle;
+  }
 }
 
 .cancelButtonAnchorLabelText {
@@ -63,6 +62,7 @@ $small-icon-size: 16px;
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
+  white-space: nowrap;
 }
 
 .blink {

--- a/src/components/BottomBar/SessionRec.jsx
+++ b/src/components/BottomBar/SessionRec.jsx
@@ -170,12 +170,11 @@ function SessionRec() {
             <Button
               className={styles.playbackButton}
               onClick={togglePlaybackPaused}
-              regular
             >
               <MdPause alt="pause" />
               {' Pause'}
             </Button>
-            <Button onClick={stopPlayback} regular>
+            <Button onClick={stopPlayback}>
               <MdStop alt="stop" />
               {' Stop playback'}
             </Button>
@@ -314,8 +313,8 @@ function SessionRec() {
               <p>Output frames</p>
               <InfoBox
                 className={styles.infoBox}
-                text={`If checked, the specified number of frames will be recorded as 
-                screenshots and saved to disk. Per default, they are saved in the  
+                text={`If checked, the specified number of frames will be recorded as
+                screenshots and saved to disk. Per default, they are saved in the
                 user/screenshots folder. This feature can not be used together with
                 'loop playback'`}
               />

--- a/src/components/common/Input/Button/Button.scss
+++ b/src/components/common/Input/Button/Button.scss
@@ -3,7 +3,7 @@
 $small-padding: calc($vertical-padding / 2) calc($base-padding / 2);
 
 .button {
-  background: $ui-background-selected;
+  background: $ui-background-buttons;
   color: $text-color-focus;
   letter-spacing: 0.08em;
   padding: $button-padding;
@@ -66,7 +66,7 @@ $small-padding: calc($vertical-padding / 2) calc($base-padding / 2);
 
   &:not(:disabled) {
     &:hover {
-      background: $ui-background-hover;
+      background: $ui-background-buttons-hover;
     }
 
     &:focus {
@@ -75,7 +75,7 @@ $small-padding: calc($vertical-padding / 2) calc($base-padding / 2);
   }
 
   &:active {
-    background: $ui-background-active;
+    background: $ui-background-buttons;
     color: $text-color-blur;
   }
 

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -14,6 +14,8 @@ $ui-background-hover: rgba(white, 0.08);
 $ui-background-selected: rgba(white, 0.05);
 $ui-background-active: rgba(white, 0.05);
 $ui-background-slider-input: rgba(white, 0.1);
+$ui-background-buttons: rgba(white, 0.12);
+$ui-background-buttons-hover: rgba(white, 0.2);
 
 $ui-danger: $red;
 $ui-warning: $orange;


### PR DESCRIPTION
Also show which scene graph node the camera is flying to, instead of the current anchor node

Closes OpenSpace/OpenSpace#2665

Related to OpenSpace PR: https://github.com/OpenSpace/OpenSpace/pull/2980

Adds a special topic for the camera paths. I first considered including the information together with the other camera topic, but that topic sends information about the updated camera position **constantly** when subscribed to. To only get updates when a camera path is playing, it was better to use a separate topic

Attached a demo video in the core slack, but here it is again

https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/assets/8808894/4604c2eb-4634-4e07-863f-bf2a4a1e5999



