### PR TITLE
Issue/3082 - Update Scene pane search and how to show hidden nodes

### DIFF
--- a/src/components/Sidebar/Properties/PropertyOwner.jsx
+++ b/src/components/Sidebar/Properties/PropertyOwner.jsx
@@ -15,7 +15,6 @@ import {
   getSceneGraphNodeFromUri,
   isDeadEnd,
   isGlobeBrowsingLayer,
-  isPropertyOwnerHidden,
   isPropertyVisible,
   isSceneGraphNode,
   nodeExpansionIdentifier
@@ -56,10 +55,9 @@ function PropertyOwner({
     const data = state.propertyTree.propertyOwners[uri];
     const subownersRaw = data ? data.subowners : [];
     const shownSubowners = subownersRaw.filter((subowner) => {
-      const isOwnerVisible = !isPropertyOwnerHidden(properties, subowner);
       const isOwnerDeadEnd = isDeadEnd(propertyOwners, properties, subowner);
 
-      return isOwnerVisible && !isOwnerDeadEnd && !isGlobeBrowsingLayer(subowner);
+      return !isOwnerDeadEnd && !isGlobeBrowsingLayer(subowner);
     });
 
     if (shouldSortAlphabetically(uri)) {
@@ -96,10 +94,6 @@ function PropertyOwner({
     return (renderableTypeProp !== undefined);
   });
 
-  const isHidden = useSelector((state) => {
-    const showHidden = state.propertyTree.properties['OpenSpaceEngine.ShowHiddenSceneGraphNodes'];
-    return isPropertyOwnerHidden(state.propertyTree.properties, uri) && !showHidden.value;
-  });
   // @TODO (emmbr 2023-02-21) Make this work for other propety owners that have
   // descriptions too, such as geojson layers
   const isSceneGraphNodeOrLayer = isSceneGraphNode(uri) || isGlobeBrowsingLayer(uri);
@@ -237,7 +231,7 @@ function PropertyOwner({
     );
   }
 
-  return !isHidden && (
+  return (
     <ToggleContent
       header={header()}
       expanded={isExpanded}

--- a/src/components/Sidebar/ScenePane.jsx
+++ b/src/components/Sidebar/ScenePane.jsx
@@ -7,6 +7,7 @@ import { useLocalStorageState } from '../../utils/customHooks';
 import { checkIfVisible, isPropertyOwnerHidden } from '../../utils/propertyTreeHelpers';
 import { ObjectWordBeginningSubstring } from '../../utils/StringMatchers';
 import { FilterList, FilterListData, FilterListFavorites } from '../common/FilterList/FilterList';
+import InfoBox from '../common/InfoBox/InfoBox';
 import Checkbox from '../common/Input/Checkbox/Checkbox';
 import LoadingBlocks from '../common/LoadingBlock/LoadingBlocks';
 import SettingsPopup from '../common/SettingsPopup/SettingsPopup';
@@ -94,7 +95,13 @@ function ScenePane({ closeCallback }) {
         wide
         style={{ padding: '2px' }}
       >
-        <p>Show only enabled</p>
+        <p>
+          Show only visible
+          <InfoBox
+            style={{ paddingLeft: '4px' }}
+            text="Visible = Enabled and not faded out"
+          />
+        </p>
       </Checkbox>
       <Checkbox
         checked={showHiddenNodes}
@@ -104,7 +111,13 @@ function ScenePane({ closeCallback }) {
         wide
         style={{ padding: '2px' }}
       >
-        <p>Show hidden scene graph nodes</p>
+        <p>
+          Show hidden scene graph nodes
+          <InfoBox
+            style={{ paddingLeft: '4px' }}
+            text="Scene graph nodes that are not marked as hidden in the asset"
+          />
+        </p>
       </Checkbox>
     </SettingsPopup>
   );

--- a/src/components/Sidebar/ScenePane.jsx
+++ b/src/components/Sidebar/ScenePane.jsx
@@ -91,10 +91,10 @@ function ScenePane({ closeCallback }) {
         style={{ padding: '2px' }}
       >
         <p>
-          Show hidden scene graph nodes
+          Show objects with GUI hidden flag
           <InfoBox
             style={{ paddingLeft: '4px' }}
-            text="Scene graph nodes that are not marked as hidden in the asset"
+            text="Show scene graph nodes that are marked as hidden in the GUI part of the asset. These are otherwise hidden in the interface"
           />
         </p>
       </Checkbox>

--- a/src/components/Sidebar/ScenePane.jsx
+++ b/src/components/Sidebar/ScenePane.jsx
@@ -25,31 +25,10 @@ function ScenePane({ closeCallback }) {
     const topLevelGroupsPaths = Object.keys(state.groups).filter((path) => {
       // Get the number of slashes in the path
       const depth = (path.match(/\//g) || []).length;
-      return depth <= 1;
-    }).map((path) => path.slice(1)); // Remove first slash
-
-    // Convert back to object
-    const topLevelGroups = topLevelGroupsPaths.reduce((obj, key) => ({ ...obj, [key]: true }), {});
-
-    // Reorder properties based on SceneProperties ordering property
-    let sortedGroups = [];
-    const ordering = state.propertyTree.properties['Modules.ImGUI.Main.SceneProperties.Ordering'];
-    if (ordering && ordering.value) {
-      ordering.value.forEach((item) => {
-        if (topLevelGroups[item]) {
-          sortedGroups.push(item);
-          delete topLevelGroups[item];
-        }
-      });
-    }
-    // Add the remaining items to the end.
-    Object.keys(topLevelGroups).forEach((item) => {
-      sortedGroups.push(item);
+      return depth === 1;
     });
-
-    // Add back the leading slash
-    sortedGroups = sortedGroups.map((path) => `/${path}`);
-    return sortedGroups;
+    // @TODO: Handle things that are outside of any group (depth === 0)?
+    return topLevelGroupsPaths;
   }, shallowEqual);
 
   const propertyOwners = useSelector((state) => state.propertyTree.propertyOwners, shallowEqual);


### PR DESCRIPTION
Instead of using the property in the OpenSpace Engine (which can now be removed), use a similar state as the show-only-enabled checkbox, for consistency

Also:
* prevent the Scene pane from re-rendering completely whenever any property value updates,
* Make it clearer that "show only enabled" actually shows only visible (or at least, now it does)
* simplify/clean up the code a bit (e.g. by removing is hidden checks in the property owner component and using legacy ImGui property for generating the groups...)

closes OpenSpace/OpenSpace#3082

https://github.com/OpenSpace/OpenSpace-WebGuiFrontend/assets/8808894/f4dc86e5-2313-41ab-9953-83b53d1365ec

