### PR TITLE
fixes for breaking time greater than 9999

### DIFF
--- a/src/api/Middleware/skybrowser.js
+++ b/src/api/Middleware/skybrowser.js
@@ -52,7 +52,6 @@ const getWwtData = async (luaApi, callback) => {
 };
 
 async function setupSubscription(store) {
-  console.log('Set up skybrowser subscription');
   skybrowserTopic = api.startTopic('skybrowser', {
     event: 'start_subscription'
   });

--- a/src/api/Reducers/shortcuts.js
+++ b/src/api/Reducers/shortcuts.js
@@ -22,7 +22,6 @@ const shortcuts = (state = defaultState, action = {}) => { // state refers to sh
         navigationPath: action.payload
       };
     case actionTypes.toggleKeybindViewer:
-      console.log('was showing?', state.showKeybinds);
       return {
         ...state,
         showKeybinds: !state.showKeybinds

--- a/src/api/Reducers/time.js
+++ b/src/api/Reducers/time.js
@@ -77,15 +77,15 @@ const time = (state = defaultState, action = {}) => {
         // Make optimized time that only updates every second
         const date = new Date(dateStringWithTimeZone(newTime));
         date.setMilliseconds(0);
-        let iso = ""
-        let newiso = ""
+        let iso = "";
+        let newiso = "";
         try {
-          let iso = date.toISOString()
+          let iso = date.toISOString();
         } catch {
           let iso = newTime;
         }
         try {
-          let newiso = newState.timeCapped.toISOString()
+          let newiso = newState.timeCapped.toISOString();
         } catch {
           let newiso = newTime;
         }

--- a/src/api/Reducers/time.js
+++ b/src/api/Reducers/time.js
@@ -62,16 +62,38 @@ const time = (state = defaultState, action = {}) => {
       const newState = { ...state };
 
       if (newTime !== undefined) {
-        newState.time = new Date(dateStringWithTimeZone(newTime));
+        try {
+          let ztime = new Date(dateStringWithTimeZone(newTime));
+          if (!isNaN(ztime)) {
+            newState.time = ztime
+          } else {
+            newState.time = newTime
+          }
+        }
+        catch (e) {
+          newState.time = newTime;
+        }
 
         // Make optimized time that only updates every second
         const date = new Date(dateStringWithTimeZone(newTime));
         date.setMilliseconds(0);
+        let iso = ""
+        let newiso = ""
+        try {
+          let iso = date.toISOString()
+        } catch {
+          let iso = newTime;
+        }
+        try {
+          let newiso = newState.timeCapped.toISOString()
+        } catch {
+          let newiso = newTime;
+        }
         // If it is the first time the time is sent, just set the state
         // Else cap the update of the state to every second for performance
         if (!state.timeCapped) {
-          newState.timeCapped = date;
-        } else if (date.toISOString() !== newState.timeCapped.toISOString()) {
+          newState.timeCapped = newTime;
+        } else if (iso !== newiso) {
           newState.timeCapped = date;
         }
       }

--- a/src/api/Reducers/time.js
+++ b/src/api/Reducers/time.js
@@ -80,14 +80,14 @@ const time = (state = defaultState, action = {}) => {
         let iso = "";
         let newiso = "";
         try {
-          let iso = date.toISOString();
+          iso = date.toISOString();
         } catch {
-          let iso = newTime;
+          iso = newTime;
         }
         try {
-          let newiso = newState.timeCapped.toISOString();
+          newiso = newState.timeCapped.toISOString();
         } catch {
-          let newiso = newTime;
+          newiso = newTime;
         }
         // If it is the first time the time is sent, just set the state
         // Else cap the update of the state to every second for performance

--- a/src/components/BottomBar/TimePicker.jsx
+++ b/src/components/BottomBar/TimePicker.jsx
@@ -59,18 +59,26 @@ function TimePicker() {
     // Spice, that is handling the time parsing in OpenSpace does not support
     // ISO 8601-style time zones (the Z). It does, however, always assume that UTC
     // is given.
-    const fixedTimeString = newTime.toJSON().replace('Z', '');
-    luaApi.time.setTime(fixedTimeString);
+    try {
+      const fixedTimeString = newTime.toJSON().replace('Z', '');
+      luaApi.time.setTime(fixedTimeString);  
+    } catch {
+      luaApi.time.setTime(time);  
+    }
   }
 
   function setDateRelative(delta) {
-    const newTime = new Date(time);
-    newTime.setSeconds(newTime.getSeconds() + delta);
-    // Spice, that is handling the time parsing in OpenSpace does not support
-    // ISO 8601-style time zones (the Z). It does, however, always assume that UTC
-    // is given.
-    const fixedTimeString = newTime.toJSON().replace('Z', '');
-    luaApi.time.setTime(fixedTimeString);
+    try {
+      const newTime = new Date(time);
+      newTime.setSeconds(newTime.getSeconds() + delta);
+      // Spice, that is handling the time parsing in OpenSpace does not support
+      // ISO 8601-style time zones (the Z). It does, however, always assume that UTC
+      // is given.
+      const fixedTimeString = newTime.toJSON().replace('Z', '');
+      luaApi.time.setTime(fixedTimeString);  
+    } catch {
+      luaApi.time.setTime(time);  
+    }
   }
 
   function interpolateDate(newTime) {

--- a/src/components/BottomBar/TimePicker.jsx
+++ b/src/components/BottomBar/TimePicker.jsx
@@ -112,8 +112,15 @@ function TimePicker() {
   }
 
   function timeLabel() {
-    return time && time.toUTCString();
-  }
+    if (time) {
+      try {
+        return time.toUTCString();
+      } catch {
+        return time;
+      }
+    }
+    return time;
+}
 
   function setToPendingTime() {
     setDate(pendingTime);

--- a/src/components/BottomBar/TimePicker.jsx
+++ b/src/components/BottomBar/TimePicker.jsx
@@ -128,7 +128,7 @@ function TimePicker() {
       }
     }
     return time;
-}
+  }
 
   function setToPendingTime() {
     setDate(pendingTime);

--- a/src/components/common/Calendar/Calendar.jsx
+++ b/src/components/common/Calendar/Calendar.jsx
@@ -149,7 +149,6 @@ function Calendar({
     return classes;
   }
 
-
   return (
     <section>
       <header className={styles.header}>

--- a/src/components/common/Calendar/Calendar.jsx
+++ b/src/components/common/Calendar/Calendar.jsx
@@ -35,6 +35,19 @@ function Calendar({
   const [viewedMonth, setViewedMonth] = React.useState(currentTime);
   const [viewFreeCoupled, setViewFreeCoupled] = React.useState(false);
 
+  let monthNumber = 0;
+  try {
+    monthNumber = viewedMonth.getMonth();
+  } catch {
+
+  }
+  let fy = 0;
+  try {
+    fy = currentTime.getFullYear();
+  } catch {
+
+  }
+
   React.useEffect(() => {
     // update calendar focus (unless user has moved away from previously given active month)
     const isCurrentTimeViewed = Calendar.isSameDay(
@@ -63,28 +76,37 @@ function Calendar({
     if (add === 0) {
       return viewedMonth;
     }
-
-    const newDate = new Date(viewedMonth.getTime());
-    newDate.setMonth(newDate.getMonth() + add);
-    return newDate;
+    try {
+      const newDate = new Date(viewedMonth.getTime());
+      newDate.setMonth(newDate.getMonth() + add);
+      return newDate;
+    } catch {
+      const newDate = new Date();
+      newDate.setMonth(newDate.getMonth() + add);
+      return newDate;
+    }
   }
 
   function daysToDisplay() {
-    const prevMonth = month(-1);
-    const thisMonth = month();
-    const nextMonth = month(1);
-    const days = Calendar.daysOfMonth(Calendar.toStartOfMonth(thisMonth));
-    const prev = Calendar.daysOfMonth(Calendar.toStartOfMonth(prevMonth));
-    const next = Calendar.daysOfMonth(Calendar.toStartOfMonth(nextMonth));
+    try {
+      const prevMonth = month(-1);
+      const thisMonth = month();
+      const nextMonth = month(1);
+      const days = Calendar.daysOfMonth(Calendar.toStartOfMonth(thisMonth));
+      const prev = Calendar.daysOfMonth(Calendar.toStartOfMonth(prevMonth));
+      const next = Calendar.daysOfMonth(Calendar.toStartOfMonth(nextMonth));
 
-    const rotatedDays = rotate(DaysInWeekBefore, 7 - WeekStartsOn);
-    const daysFromPrevMonth = rotatedDays[thisMonth.getDay()];
+      const rotatedDays = rotate(DaysInWeekBefore, 7 - WeekStartsOn);
+      const daysFromPrevMonth = rotatedDays[thisMonth.getDay()];
 
-    days.unshift(...prev.slice(-1 * daysFromPrevMonth));
-    const daysFromNextMonth = ExpectedDaysInCalendar - days.length;
-    days.push(...next.slice(0, daysFromNextMonth));
+      days.unshift(...prev.slice(-1 * daysFromPrevMonth));
+      const daysFromNextMonth = ExpectedDaysInCalendar - days.length;
+      days.push(...next.slice(0, daysFromNextMonth));
 
-    return days;
+      return days;
+    } catch {
+      return [];
+    }
   }
 
   function setCurrentMonth() {
@@ -127,6 +149,7 @@ function Calendar({
     return classes;
   }
 
+
   return (
     <section>
       <header className={styles.header}>
@@ -139,7 +162,7 @@ function Calendar({
               <MdToday />
             </Button>
           )}
-          {`${Months[viewedMonth.getMonth()]} ${currentTime.getFullYear()}`}
+          {`${Months[monthNumber]} ${fy}`}
         </span>
         <Button regular transparent small onClick={() => stepViewMonth(1)}>
           <MdChevronRight />
@@ -174,37 +197,54 @@ function Calendar({
 
 // Static functions
 Calendar.daysOfMonth = (month) => {
-  const iterator = new Date(month.getTime());
-  const days = [];
-
-  while (iterator.getMonth() === month.getMonth()) {
-    days.push(Calendar.copy(iterator));
-    iterator.setDate(iterator.getDate() + 1);
+  try {
+    const iterator = new Date(month.getTime());
+    const days = [];
+    while (iterator.getMonth() === month.getMonth()) {
+      days.push(Calendar.copy(iterator));
+      iterator.setDate(iterator.getDate() + 1);
+    }
+    return days;
+  } catch {
+    return [];
   }
-
-  return days;
 };
 
-Calendar.isSameDay = (a, b) => a.getFullYear() === b.getFullYear() &&
+Calendar.isSameDay = (a, b) => {
+  try {
+    a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
     a.getDate() === b.getDate();
-
+  } catch {
+    return false;
+  }
+};
 /**
  * set the date component to 1
  * @param day - remains unchanged
  * @returns {Date}
  */
 Calendar.toStartOfMonth = (day) => {
-  const newDay = Calendar.copy(day);
-  newDay.setDate(1);
+  try {
+    const newDay = Calendar.copy(day);
+    newDay.setDate(1);
   return newDay;
+  } catch {
+    return "1"
+  }
 };
 
 /**
  * copy date
  * @param date
  */
-Calendar.copy = (date) => new Date(date.getTime());
+Calendar.copy = (date) => {
+  try {
+    new Date(date.getTime())
+  } catch {
+    return date
+  }
+};
 
 Calendar.propTypes = {
   currentTime: PropTypes.instanceOf(Date),

--- a/src/components/common/Calendar/Calendar.jsx
+++ b/src/components/common/Calendar/Calendar.jsx
@@ -38,15 +38,12 @@ function Calendar({
   let monthNumber = 0;
   try {
     monthNumber = viewedMonth.getMonth();
-  } catch {
+  } catch { /* empty */ }
 
-  }
-  let fy = 0;
+  let fullYear = 0;
   try {
-    fy = currentTime.getFullYear();
-  } catch {
-
-  }
+    fullYear = currentTime.getFullYear();
+  } catch { /* empty */ }
 
   React.useEffect(() => {
     // update calendar focus (unless user has moved away from previously given active month)
@@ -76,15 +73,11 @@ function Calendar({
     if (add === 0) {
       return viewedMonth;
     }
+    let newDate = new Date();
     try {
-      const newDate = new Date(viewedMonth.getTime());
-      newDate.setMonth(newDate.getMonth() + add);
-      return newDate;
-    } catch {
-      const newDate = new Date();
-      newDate.setMonth(newDate.getMonth() + add);
-      return newDate;
-    }
+      newDate = new Date(viewedMonth.getTime());
+    } catch { /* empty */ }
+    return newDate;
   }
 
   function daysToDisplay() {
@@ -161,7 +154,7 @@ function Calendar({
               <MdToday />
             </Button>
           )}
-          {`${Months[monthNumber]} ${fy}`}
+          {`${Months[monthNumber]} ${fullYear}`}
         </span>
         <Button regular transparent small onClick={() => stepViewMonth(1)}>
           <MdChevronRight />
@@ -211,9 +204,9 @@ Calendar.daysOfMonth = (month) => {
 
 Calendar.isSameDay = (a, b) => {
   try {
-    a.getFullYear() === b.getFullYear() &&
+    return (a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
+    a.getDate() === b.getDate());
   } catch {
     return false;
   }
@@ -227,9 +220,9 @@ Calendar.toStartOfMonth = (day) => {
   try {
     const newDay = Calendar.copy(day);
     newDay.setDate(1);
-  return newDay;
+    return newDay;
   } catch {
-    return "1"
+    return '1';
   }
 };
 
@@ -239,9 +232,9 @@ Calendar.toStartOfMonth = (day) => {
  */
 Calendar.copy = (date) => {
   try {
-    new Date(date.getTime())
+    return new Date(date.getTime());
   } catch {
-    return date
+    return date;
   }
 };
 

--- a/src/components/common/Input/Time/Time.jsx
+++ b/src/components/common/Input/Time/Time.jsx
@@ -53,7 +53,6 @@ function zeroPad(number) {
 
 function Time({ elements, onChange, time }) {
   const hasCallback = onChange !== null;
-
   function shouldInclude(what) {
     return elements.includes(what);
   }
@@ -143,13 +142,21 @@ function Time({ elements, onChange, time }) {
 
   function fullYear() {
     const mm = shouldInclude(Elements.Month);
-    return wrap(`${zeroPad(time.getUTCFullYear())}`, 'FullYear', mm && ':');
+    try {
+      return wrap(`${zeroPad(time.getUTCFullYear())}`, 'FullYear', mm && ':');
+    } catch {
+      return wrap(time.split(' ')[0], 'FullYear', mm && ':');
+    }
   }
 
   function month() {
     const dd = shouldInclude(Elements.Date);
-
-    let mm = Months[time.getUTCMonth()];
+    let mm = ''
+    try {
+      mm = Months[time.getUTCMonth()];
+    } catch {
+      mm = time.split(' ')[1];
+    }
     if (!mm) {
       mm = Months[0];
     }
@@ -160,34 +167,64 @@ function Time({ elements, onChange, time }) {
 
   function date() {
     const hh = shouldInclude(Elements.Hours);
-    const dd = time.getUTCDate();
+    let dd = 0;
+    try {
+      dd = time.getUTCDate();
+    } catch {
+      dd = time.split(' ')[2];
+    }
     const zpd = zeroPad(dd);
     return wrap(`${zpd}`, 'Date', hh && ':');
   }
 
   function hours() {
     const mm = shouldInclude(Elements.Minutes);
-    const hh = time.getUTCHours();
+    let hh = 0;
+    try {
+      hh = time.getUTCHours();
+    } catch {
+      try {
+        hh = time.split(' ')[3].split(":")[0];
+      } catch {
+        hh = 0
+      }
+    }
     const zph = zeroPad(hh);
     return wrap(`${zph}`, 'Hours', mm && ':');
   }
 
   function minutes() {
     const ss = shouldInclude(Elements.Seconds);
-    const mm = time.getUTCMinutes();
+    let mm = 0;
+    try {
+      mm = time.getUTCMinutes();
+    } catch {
+      mm = time.split(' ')[3].split(":")[1];
+    }
     const zpm = zeroPad(mm);
     return wrap(`${zpm}`, 'Minutes', ss && ':');
   }
 
   function seconds() {
     const ms = shouldInclude(Elements.Milliseconds);
-    const ss = time.getUTCSeconds();
+    let ss = 0;
+    try {
+      ss = time.getUTCSeconds();
+    } catch {
+      ss = time.split(' ')[3].split(":")[2].split('.')[0];
+    }
     const zps = zeroPad(ss);
     return wrap(`${zps}`, 'Seconds', ms && '.');
   }
 
   function milliseconds() {
-    const ms = time.getUTCMilliseconds();
+    let ms = 0;
+    try {
+      ms = time.getUTCMilliseconds();
+    } catch {
+      ms = time.split(' ')[3].split(":")[2].split('.')[1];
+    }
+
     return wrap(ms, 'Milliseconds');
   }
 

--- a/src/components/common/Input/Time/Time.jsx
+++ b/src/components/common/Input/Time/Time.jsx
@@ -151,7 +151,7 @@ function Time({ elements, onChange, time }) {
 
   function month() {
     const dd = shouldInclude(Elements.Date);
-    let mm = ''
+    let mm = '';
     try {
       mm = Months[time.getUTCMonth()];
     } catch {
@@ -184,7 +184,7 @@ function Time({ elements, onChange, time }) {
       hh = time.getUTCHours();
     } catch {
       try {
-        hh = time.split(' ')[3].split(":")[0];
+        hh = time.split(' ')[3].split(':')[0];
       } catch {
         hh = 0
       }
@@ -199,7 +199,7 @@ function Time({ elements, onChange, time }) {
     try {
       mm = time.getUTCMinutes();
     } catch {
-      mm = time.split(' ')[3].split(":")[1];
+      mm = time.split(' ')[3].split(':')[1];
     }
     const zpm = zeroPad(mm);
     return wrap(`${zpm}`, 'Minutes', ss && ':');
@@ -211,7 +211,7 @@ function Time({ elements, onChange, time }) {
     try {
       ss = time.getUTCSeconds();
     } catch {
-      ss = time.split(' ')[3].split(":")[2].split('.')[0];
+      ss = time.split(' ')[3].split(':')[2].split('.')[0];
     }
     const zps = zeroPad(ss);
     return wrap(`${zps}`, 'Seconds', ms && '.');
@@ -222,7 +222,7 @@ function Time({ elements, onChange, time }) {
     try {
       ms = time.getUTCMilliseconds();
     } catch {
-      ms = time.split(' ')[3].split(":")[2].split('.')[1];
+      ms = time.split(' ')[3].split(':')[2].split('.')[1];
     }
 
     return wrap(ms, 'Milliseconds');

--- a/src/components/common/Input/Time/Time.jsx
+++ b/src/components/common/Input/Time/Time.jsx
@@ -186,7 +186,7 @@ function Time({ elements, onChange, time }) {
       try {
         hh = time.split(' ')[3].split(':')[0];
       } catch {
-        hh = 0
+        hh = 0;
       }
     }
     const zph = zeroPad(hh);


### PR DESCRIPTION
Closes https://github.com/OpenSpace/OpenSpace/issues/2942


however this is really only fixing 3/4 of the issues. 

Right now it will display the correct time, and nothing will crash, but the calendar and setting dates still don't work when you are outside of the ISO time range (i.e 9999). 

There is more handling to be added to Time.jsx and Calendar.jsx to handle when the time is just a string and not a Date() 
