### PR TITLE
Make property tree be cleared when the property tree reloads

### DIFF
--- a/src/api/Actions/actionTypes.js
+++ b/src/api/Actions/actionTypes.js
@@ -6,6 +6,7 @@ const actionTypes = {
   subscribeToProperty: 'PROPERTY_TREE_SUBSCRIBE',
   unsubscribeToProperty: 'PROPERTY_TREE_UNSUBSCRIBE',
   addPropertyOwners: 'PROPERTY_TREE_ADD_OWNERS',
+  clearPropertyTree: 'CLEAR_PROPERTY_TREE',
   addProperties: 'PROPERTY_TREE_ADD_PROPERTIES',
   removePropertyOwners: 'PROPERTY_TREE_REMOVE_OWNERS',
   removeProperties: 'PROPERTY_TREE_REMOVE_PROPERTIES',

--- a/src/api/Actions/index.js
+++ b/src/api/Actions/index.js
@@ -23,6 +23,11 @@ export const addPropertyOwners = (propertyOwners) => ({
   }
 });
 
+export const clearPropertyTree = () => ({
+  type: actionTypes.clearPropertyTree,
+  payload: {}
+});
+
 export const addProperties = (properties) => ({
   type: actionTypes.addProperties,
   payload: {

--- a/src/api/Middleware/propertyTree.js
+++ b/src/api/Middleware/propertyTree.js
@@ -3,10 +3,10 @@ import { throttle } from 'lodash/function';
 import {
   addProperties,
   addPropertyOwners,
+  clearPropertyTree,
   refreshGroups,
   reloadPropertyTree,
-  updatePropertyValue,
-  clearPropertyTree
+  updatePropertyValue
 } from '../Actions';
 import actionTypes from '../Actions/actionTypes';
 import api from '../api';

--- a/src/api/Middleware/propertyTree.js
+++ b/src/api/Middleware/propertyTree.js
@@ -5,7 +5,8 @@ import {
   addPropertyOwners,
   refreshGroups,
   reloadPropertyTree,
-  updatePropertyValue
+  updatePropertyValue,
+  clearPropertyTree
 } from '../Actions';
 import actionTypes from '../Actions/actionTypes';
 import api from '../api';
@@ -196,6 +197,7 @@ const propertyTree = (store) => (next) => (action) => {
       break;
     }
     case actionTypes.reloadPropertyTree: {
+      store.dispatch(clearPropertyTree());
       getPropertyTree(store.dispatch);
       break;
     }

--- a/src/api/Reducers/propertyTree.js
+++ b/src/api/Reducers/propertyTree.js
@@ -9,6 +9,7 @@ import actionTypes from '../Actions/actionTypes';
 // removeProperties
 // updatePropertyValue
 // setPropertyValue
+// clearPropertyTree
 
 const property = (state = {}, action = {}) => {
   switch (action.type) {
@@ -45,6 +46,9 @@ const properties = (state = {}, action = {}) => {
       });
       return newState;
     }
+    case actionTypes.clearPropertyTree: {
+      return {};
+    }
     case actionTypes.updatePropertyValue:
       return {
         ...state,
@@ -70,6 +74,9 @@ const propertyOwners = (state = {}, action = {}) => {
         };
       });
       return newState;
+    }
+    case actionTypes.clearPropertyTree: {
+      return {};
     }
     case actionTypes.removePropertyOwners: {
       const newState = { ...state };


### PR DESCRIPTION
This is a small fix to clear property tree when doing a reload. This is useful when having the ui in a browser, adding some exoplanets for example, and then restarting OpenSpace. Previously this did not remove these exoplanets in the browser ui, but with this pr it will.