### PR TITLE
Remove `react-input-autosize` dependency, that led to dependency conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "react-dom": "^18.2.0",
         "react-draggable": "^4.4.3",
         "react-icons": "^4.10.1",
-        "react-input-autosize": "^3.0.0",
         "react-lazy-load-image-component": "^1.5.5",
         "react-redux": "^7.2.8",
         "react-refresh": "^0.14.0",
@@ -34,7 +33,7 @@
         "react-virtualized": "^9.22.3",
         "redux": "^4.2.0",
         "sass": "^1.49.9",
-        "shallow-equal": "^1.2.1",
+        "shallow-equal": "^3.1.0",
         "simple-keyboard-layouts": "^3.0.176",
         "spherical-geometry-js": "^3.0.0",
         "svg-react-loader": "^0.4.6"
@@ -7727,17 +7726,6 @@
         "react": "*"
       }
     },
-    "node_modules/react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8600,9 +8588,10 @@
       }
     },
     "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -15860,14 +15849,6 @@
       "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
       "requires": {}
     },
-    "react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -16512,9 +16493,9 @@
       }
     },
     "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.3",
     "react-icons": "^4.10.1",
-    "react-input-autosize": "^3.0.0",
     "react-lazy-load-image-component": "^1.5.5",
     "react-redux": "^7.2.8",
     "react-refresh": "^0.14.0",

--- a/src/components/common/Input/InlineInput/InlineInput.jsx
+++ b/src/components/common/Input/InlineInput/InlineInput.jsx
@@ -15,7 +15,7 @@ import styles from './InlineInput.scss';
  * be looked at again. // Emma (2024-08-09)
  */
 function InlineInput({
-  className, type, value, onEnter, onChange, noExtraWidth, id, ...props
+  className, type, value, onEnter, onChange, id, ...props
 }) {
   const [storedValue, setStoredValue] = React.useState(value);
   const [isFocused, setIsFocused] = React.useState(false);
@@ -25,7 +25,7 @@ function InlineInput({
   const span = React.useRef();
 
   React.useEffect(() => {
-    setWidth(span.current.offsetWidth);
+    setWidth(span.current.clientWidth);
   }, [storedValue]);
 
   React.useEffect(() => {
@@ -60,7 +60,7 @@ function InlineInput({
     // To place it on top over and behind the actual input
     position: 'absolute',
     zIndex: -1
-  }
+  };
 
   return (
     <div>
@@ -75,7 +75,6 @@ function InlineInput({
         onKeyUp={onKeyUp}
         onBlur={onBlur}
         onFocus={onFocus}
-        placeholder='test'
       />
     </div>
   );

--- a/src/components/common/Input/InlineInput/InlineInput.scss
+++ b/src/components/common/Input/InlineInput/InlineInput.scss
@@ -20,7 +20,6 @@
     background: transparent;
     color: $text-color-focus;
     border: none;
-    width: fit-content;
     &:focus,
     &:hover {
       outline: 0;

--- a/src/components/common/Input/InlineInput/InlineInput.scss
+++ b/src/components/common/Input/InlineInput/InlineInput.scss
@@ -20,7 +20,7 @@
     background: transparent;
     color: $text-color-focus;
     border: none;
-
+    width: fit-content;
     &:focus,
     &:hover {
       outline: 0;

--- a/src/components/common/Input/InlineInput/InlineInput.scss
+++ b/src/components/common/Input/InlineInput/InlineInput.scss
@@ -2,7 +2,7 @@
 
 .input {
   background: $ui-background-selected;
-  border: 0;
+  border: none;
   box-sizing: content-box;
   color: $text-color-focus;
   display: inline;
@@ -16,14 +16,9 @@
     display: none;
   }
 
-  input {
-    background: transparent;
-    color: $text-color-focus;
-    border: none;
-    &:focus,
-    &:hover {
-      outline: 0;
-      background: $ui-background-hover;
-    }
+  &:focus,
+  &:hover {
+    outline: 0;
+    background: $ui-background-hover;
   }
 }

--- a/src/components/common/Input/Time/Time.jsx
+++ b/src/components/common/Input/Time/Time.jsx
@@ -118,11 +118,9 @@ function Time({ elements, onChange, time }) {
           <span key={`span${what}`} ref={(el) => { ref.current[what] = el; }}>
             <InlineInput
               value={inner}
-              size={width}
               className={styles.textInput}
               onEnter={onInput(what)}
               type={type}
-              noExtraWidth
             />
           </span>
           <Button nopadding transparent onClick={(e) => onClick(e, what, -1)}>

--- a/src/components/common/Input/Time/Time.scss
+++ b/src/components/common/Input/Time/Time.scss
@@ -5,7 +5,7 @@
 }
 
 .textInput {
-  padding: calc($base-padding / 2) !important;
+  padding: calc(0.4 * $base-padding) !important;
 }
 
 .element {


### PR DESCRIPTION
It does not support React version 18 and has not been updated for 4 years. It led to very annoying conflicts when trying to run `npm install`. With this fix, we no longer need to use the `--legacy-peer-deps` flag. 

We only really used in it in one place, to size the input components for the Time picker to fit the text that's in them:
![image](https://github.com/user-attachments/assets/25c21ec1-b1fa-4e96-9e23-9be4a1c9ed73)

For now, I just updated the InlineInput component to always resize based on the input, which IMO could be considered confusing and does not reflect the intentional use case of the component (whatever "inline" is supposed to mean). However, the entire `Time` component requires an update to prevent entering invalid values. When we do that, this `InlineInput` component should also be readdressed.


Note that some of the `shallow-equal` package-lock.json changes are in here as well... This is all part of an ongoing work on cleaning up and updating the dependencies. But fixing this dependency conflict was the most urgent


The input now also blurs on enter (it didn't use to)
